### PR TITLE
Check for dependencies at setup time

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -98,6 +98,8 @@ meta = dict(name='bdsf',
                 'Topic :: Scientific/Engineering :: Astronomy'
                 ],
             ext_modules=extensions,
+            install_requires=['backports.shutil_get_terminal_size',
+                              'numpy', 'scipy'],
             scripts = ['bdsf/pybdsf', 'bdsf/pybdsm'],
             zip_safe = False
             )


### PR DESCRIPTION
Checking for some basic dependencies. We could add checking for more complicated dependencies (like `fits` from either casacore or astropy) later.