### PR TITLE
Add shebang to command line tool

### DIFF
--- a/bdsf/pybdsf
+++ b/bdsf/pybdsf
@@ -1,8 +1,10 @@
+#!/usr/bin/env python
+
 """Interactive PyBDSF shell.
 
 This module initializes the interactive PyBDSF shell, which is a customized
 IPython enviroment. It should be called from the terminal prompt using the
-"pybdsf".
+command "pybdsf".
 """
 import bdsf
 from bdsf.image import Image


### PR DESCRIPTION
Adding a shebang will make starting the command line tool as easy as typing `pybdsf` (no `python` in front of it).