### PR TITLE
Appended image FITS header into catalog FITS header

### DIFF
--- a/bdsf/output.py
+++ b/bdsf/output.py
@@ -450,6 +450,11 @@ def write_fits_list(img, filename=None, sort_by='index', objtype='gaul',
         tbhdu.header['INIMAGE'] = (img.filename, 'Filename of image')
         tbhdu.header['FREQ0'] = (float(freq), 'Reference frequency')
         tbhdu.header['EQUINOX'] = (img.equinox, 'Equinox')
+
+    for key in img.header.keys():
+        if key=="HISTORY": continue
+        tbhdu.header['I_%s'%key]=img.header[key]
+
     if filename is None:
         filename = img.imagename + '.' + objtype + '.fits'
     if os.path.exists(filename) and clobber == False:


### PR DESCRIPTION
Small hack to implement issue https://github.com/lofar-astron/PyBDSF/issues/52. In order not to break any keyword, the image keyword in the catalog header is `I_CTYPE1` instead of `CTYPE1` etc