### PR TITLE
Add support for Boost 1.65 and above

### DIFF
--- a/src/c++/MGFunction.h
+++ b/src/c++/MGFunction.h
@@ -7,6 +7,12 @@
 #include <boost/python.hpp>
 
 using namespace boost::python;
+#if BOOST_VERSION < 106500
+  typedef typename pyndarray pyndarray;
+#else
+  #include <boost/python/numpy.hpp>
+  typedef typename numpy::ndarray pyndarray;
+#endif
 
 /*!
   \class MGFunction
@@ -46,7 +52,7 @@ using namespace boost::python;
 class MGFunction
 {
  public:
-  MGFunction(numeric::array data, numeric::array mask, double weight);
+  MGFunction(pyndarray data, pyndarray mask, double weight);
   ~MGFunction();
   
   ////////////////////////////////
@@ -120,9 +126,9 @@ protected:
   /*! number of fitted (unmasked) datapoints */
   unsigned m_ndata;
   /*! Data array */
-  numeric::array m_data;
+  pyndarray m_data;
   /*! Mask array */
-  numeric::array m_mask;
+  pyndarray m_mask;
   
  private:
   /*! prevent copying of the MGFunction objects */

--- a/src/c++/MGFunction1.cc
+++ b/src/c++/MGFunction1.cc
@@ -29,7 +29,7 @@ namespace n = num_util;
 //
 // Constructor -- check data types/shapes and store them
 //
-MGFunction::MGFunction(numeric::array data, numeric::array mask, double weight)
+MGFunction::MGFunction(pyndarray data, pyndarray mask, double weight)
   :  m_weight(weight), m_npar(0), m_data(data), m_mask(mask)
 {
   py_assert(n::rank(data) == 2 && n::rank(mask) == 2,
@@ -225,7 +225,7 @@ void MGFunction::register_class()
 			"and implements all math required to use it for fitting.\n\n"
 			"NEVER EVER USE IT IN MULTITHREADED SOFTWARE WITHOUT APPROPRIATE LOCKING\n"
 			"IT'S INTERNAL CACHES ARE NOT THREAD-SAFE\n\n",
-			init<numeric::array, numeric::array, 
+			init<pyndarray, pyndarray, 
 			double>((arg("data"), "mask", arg("weight") = 1.)))
 
     .def("__len__", &MGFunction::gaul_size, 

--- a/src/c++/boost_python.h
+++ b/src/c++/boost_python.h
@@ -11,7 +11,11 @@
 
 #include <boost/version.hpp>
 #include <boost/python.hpp>
+#include <numpy/arrayobject.h>
 #include <boost/python/detail/api_placeholder.hpp>
+#if BOOST_VERSION > 106500
+  #include <boost/python/numpy.hpp>
+#endif
 
 #if BOOST_VERSION > 103200
 #define ADD_PROPERTY1(name, get, doc) .add_property(name, get, doc)

--- a/src/c++/cbdsm_main.cc
+++ b/src/c++/cbdsm_main.cc
@@ -18,8 +18,10 @@ using namespace boost::python;
 BOOST_PYTHON_MODULE(_cbdsm)
 {
   import_array();
+  #if BOOST_VERSION < 106500
   numeric::array::set_module_and_type("numpy", "ndarray");
-
+  #endif
+  
   scope().attr("__doc__") = 
     "A collection of optimized C & Fortran routines for pybdsm";
 

--- a/src/c++/num_util/num_util.cpp
+++ b/src/c++/num_util/num_util.cpp
@@ -148,7 +148,7 @@ KindCharMapEntry kindCharMapEntries[] =
     KindCharMapEntry(PyArray_CDOUBLE,'D'),
     KindCharMapEntry(PyArray_OBJECT, 'O')
   };
-  
+ 
 typedef KindTypeMap::value_type  KindTypeMapEntry;
 KindTypeMapEntry kindTypeMapEntries[] =
   {
@@ -164,14 +164,10 @@ KindTypeMapEntry kindTypeMapEntries[] =
     KindTypeMapEntry('O',PyArray_OBJECT)
   };
 
-  
 int numStringEntries = sizeof(kindStringMapEntries)/sizeof(KindStringMapEntry);
 int numCharEntries = sizeof(kindCharMapEntries)/sizeof(KindCharMapEntry);
 int numTypeEntries = sizeof(kindTypeMapEntries)/sizeof(KindTypeMapEntry);
 
-
-using namespace boost::python;
-  
 static KindStringMap kindstrings(kindStringMapEntries,
                                    kindStringMapEntries + numStringEntries);
 
@@ -182,7 +178,7 @@ static KindTypeMap kindtypes(kindTypeMapEntries,
                                    kindTypeMapEntries + numTypeEntries);
 
 //Create a numarray referencing Python sequence object
-numeric::array makeNum(object x){
+pyndarray makeNum(object x){
   if (!PySequence_Check(x.ptr())){
     PyErr_SetString(PyExc_ValueError, "expected a sequence");
     throw_error_already_set();
@@ -190,33 +186,33 @@ numeric::array makeNum(object x){
   object obj(handle<>
 	     (PyArray_ContiguousFromObject(x.ptr(),PyArray_NOTYPE,0,0)));
   check_PyArrayElementType(obj);
-  return extract<numeric::array>(obj); 
+  return extract<pyndarray>(obj); 
 }
 
 //Create a one-dimensional Numeric array of length n and Numeric type t
-numeric::array makeNum(int n, PyArray_TYPES t=PyArray_DOUBLE){
+pyndarray makeNum(int n, PyArray_TYPES t=PyArray_DOUBLE){
   object obj(handle<>(PyArray_FromDims(1, &n, t)));
-  return extract<numeric::array>(obj);
+  return extract<pyndarray>(obj);
 }
   
 //Create a Numeric array with dimensions dimens and Numeric type t
-numeric::array makeNum(std::vector<int> dimens, 
+pyndarray makeNum(std::vector<int> dimens, 
 		       PyArray_TYPES t=PyArray_DOUBLE){
   object obj(handle<>(PyArray_FromDims(dimens.size(), &dimens[0], t)));
-  return extract<numeric::array>(obj);
+  return extract<pyndarray>(obj);
 }
 
-numeric::array makeNum(const numeric::array& arr){
-  //Returns a reference of arr by calling numeric::array copy constructor.
+pyndarray makeNum(const pyndarray& arr){
+  //Returns a reference of arr by calling pyndarray copy constructor.
   //The copy constructor increases arr's reference count.
-  return numeric::array(arr);
+  return pyndarray(arr);
 } 
 
-PyArray_TYPES type(numeric::array arr){
+PyArray_TYPES type(pyndarray arr){
   return PyArray_TYPES(PyArray_TYPE(arr.ptr()));
 }
 
-void check_type(boost::python::numeric::array arr, 
+void check_type(pyndarray arr, 
 		PyArray_TYPES expected_type){
   PyArray_TYPES actual_type = type(arr);
   if (actual_type != expected_type) {
@@ -230,7 +226,7 @@ void check_type(boost::python::numeric::array arr,
 }
 
 //Return the number of dimensions
-int rank(numeric::array arr){
+int rank(pyndarray arr){
   //std::cout << "inside rank" << std::endl;
   if(!PyArray_Check(arr.ptr())){
     PyErr_SetString(PyExc_ValueError, "expected a PyArrayObject");
@@ -239,7 +235,7 @@ int rank(numeric::array arr){
   return PyArray_NDIM(arr.ptr());
 }
 
-void check_rank(boost::python::numeric::array arr, int expected_rank){
+void check_rank(pyndarray arr, int expected_rank){
   int actual_rank = rank(arr);
   if (actual_rank != expected_rank) {
     std::ostringstream stream;
@@ -251,7 +247,7 @@ void check_rank(boost::python::numeric::array arr, int expected_rank){
   return;
 }
 
-int size(numeric::array arr)
+int size(pyndarray arr)
 {
   if(!PyArray_Check(arr.ptr())){
     PyErr_SetString(PyExc_ValueError, "expected a PyArrayObject");
@@ -260,7 +256,7 @@ int size(numeric::array arr)
   return PyArray_Size(arr.ptr());
 }
 
-void check_size(boost::python::numeric::array arr, int expected_size){
+void check_size(pyndarray arr, int expected_size){
   int actual_size = size(arr);
   if (actual_size != expected_size) {
     std::ostringstream stream;
@@ -272,7 +268,7 @@ void check_size(boost::python::numeric::array arr, int expected_size){
   return;
 }
 
-std::vector<int> shape(numeric::array arr){
+std::vector<int> shape(pyndarray arr){
   std::vector<int> out_dims;
   if(!PyArray_Check(arr.ptr())){
     PyErr_SetString(PyExc_ValueError, "expected a PyArrayObject");
@@ -286,7 +282,7 @@ std::vector<int> shape(numeric::array arr){
   return out_dims;
 }
 
-int get_dim(boost::python::numeric::array arr, int dimnum){
+int get_dim(pyndarray arr, int dimnum){
   assert(dimnum >= 0);
   int the_rank=rank(arr);
   if(the_rank < dimnum){
@@ -300,7 +296,7 @@ int get_dim(boost::python::numeric::array arr, int dimnum){
   return actual_dims[dimnum];
 }
 
-void check_shape(boost::python::numeric::array arr, std::vector<int> expected_dims){
+void check_shape(pyndarray arr, std::vector<int> expected_dims){
   std::vector<int> actual_dims = shape(arr);
   if (actual_dims != expected_dims) {
     std::ostringstream stream;
@@ -312,7 +308,7 @@ void check_shape(boost::python::numeric::array arr, std::vector<int> expected_di
   return;
 }
 
-void check_dim(boost::python::numeric::array arr, int dimnum, int dimsize){
+void check_dim(pyndarray arr, int dimnum, int dimsize){
   std::vector<int> actual_dims = shape(arr);
   if(actual_dims[dimnum] != dimsize){
     std::ostringstream stream;
@@ -325,13 +321,13 @@ void check_dim(boost::python::numeric::array arr, int dimnum, int dimsize){
   return;
 }
 
-bool iscontiguous(numeric::array arr)
+bool iscontiguous(pyndarray arr)
 {
   //  return arr.iscontiguous();
   return PyArray_ISCONTIGUOUS(arr.ptr());
 }
 
-void check_contiguous(numeric::array arr)
+void check_contiguous(pyndarray arr)
 {
   if (!iscontiguous(arr)) {
     PyErr_SetString(PyExc_RuntimeError, "expected a contiguous array");
@@ -340,7 +336,7 @@ void check_contiguous(numeric::array arr)
   return;
 }
 
-void* data(numeric::array arr){
+void* data(pyndarray arr){
   if(!PyArray_Check(arr.ptr())){
     PyErr_SetString(PyExc_ValueError, "expected a PyArrayObject");
     throw_error_already_set();
@@ -349,7 +345,7 @@ void* data(numeric::array arr){
 }
 
 //Copy data into the array
-void copy_data(boost::python::numeric::array arr, char* new_data){
+void copy_data(pyndarray arr, char* new_data){
   char* arr_data = (char*) data(arr);
   int nbytes = PyArray_NBYTES(arr.ptr());
   for (int i = 0; i < nbytes; i++) {
@@ -359,18 +355,24 @@ void copy_data(boost::python::numeric::array arr, char* new_data){
 } 
 
 //Return a clone of this array
-numeric::array clone(numeric::array arr){
+pyndarray clone(pyndarray arr){
   object obj(handle<>(PyArray_NewCopy((PyArrayObject*)arr.ptr(),PyArray_CORDER)));
   return makeNum(obj);
 }
 
-  
-//Return a clone of this array with a new type
-numeric::array astype(boost::python::numeric::array arr, PyArray_TYPES t){
-  return (numeric::array) arr.astype(type2char(t));
-}
 
-std::vector<int> strides(numeric::array arr){
+//Return a clone of this array with a new type
+#if BOOST_VERSION < 106500
+pyndarray astype(pyndarray arr, PyArray_TYPES t){
+  return (pyndarray) arr.astype(type2char(t));
+}
+#else
+pyndarray astype(pyndarray arr, PyArray_TYPES t){
+  return (pyndarray) arr.astype(type2dtype(type2char(t)));
+}
+#endif
+
+std::vector<int> strides(pyndarray arr){
   std::vector<int> out_strides;
   if(!PyArray_Check(arr.ptr())){
     PyErr_SetString(PyExc_ValueError, "expected a PyArrayObject");
@@ -384,7 +386,7 @@ std::vector<int> strides(numeric::array arr){
   return out_strides;
 }
 
-int refcount(numeric::array arr){
+int refcount(pyndarray arr){
   return NPY_REFCOUNT(arr.ptr());
 }
 
@@ -408,6 +410,35 @@ std::string type2string(PyArray_TYPES t_type){
 char type2char(PyArray_TYPES t_type){
   return kindchars[t_type];
 }
+
+#if BOOST_VERSION >= 106500
+np::dtype type2dtype(char t){
+
+  switch(t) {
+    case 'B':
+      return np::dtype::get_builtin<unsigned char>();
+    case 'b':
+      return np::dtype::get_builtin<signed char>();
+    case 'h':
+      return np::dtype::get_builtin<short>();
+    case 'i':
+      return np::dtype::get_builtin<int>();
+    case 'l':
+      return np::dtype::get_builtin<long int>();
+    case 'f':
+      return np::dtype::get_builtin<float>();
+    case 'd':
+      return np::dtype::get_builtin<double>();
+    case 'F':
+      return np::dtype::get_builtin<std::complex<float>>();
+    case 'D':
+      return np::dtype::get_builtin<std::complex<double>>();
+    default:
+      std::cout << "nvalid character code!" << std::endl;
+      break;
+  }
+}
+#endif
 
 PyArray_TYPES char2type(char e_type){
   return kindtypes[e_type];
@@ -439,5 +470,5 @@ inline void check_size_match(std::vector<int> dims, int n)
   return;
 }
 
-} //namespace num_util
 
+} //namespace num_util

--- a/src/c++/num_util/num_util.h
+++ b/src/c++/num_util/num_util.h
@@ -19,7 +19,14 @@
 #include <map>
 #include <complex>
 
-
+#if BOOST_VERSION < 106500
+  typedef typename boost::python::numeric::array pyndarray;
+  //namespace np = boost::python::numeric;
+#else
+  #include <boost/python/numpy.hpp>
+  typedef typename boost::python::numpy::ndarray pyndarray;
+  namespace np = boost::python::numpy;
+#endif
 
 namespace num_util{
   //!
@@ -28,7 +35,7 @@ namespace num_util{
    *@param x a sequential PyObject wrapped in a Boost/Python 'object'.
    *@return a PyArrayObject wrapped in Boost/Python numeric array.
    */
-  boost::python::numeric::array makeNum(boost::python::object x);
+  pyndarray makeNum(boost::python::object x);
 
   /** 
    *Creates an one-dimensional numpy array of length n and numpy type t. 
@@ -37,7 +44,7 @@ namespace num_util{
    *@param t elements' numpy type. Default is double.
    *@return a numeric array of size n with elements initialized to zero.
    */
-  boost::python::numeric::array makeNum(int n, PyArray_TYPES t);
+  pyndarray makeNum(int n, PyArray_TYPES t);
 
   /** 
    *Creates a n-dimensional numpy array with dimensions dimens and numpy 
@@ -46,7 +53,7 @@ namespace num_util{
    *@param t elements' numpy type. Default is double.
    *@return a numeric array of shape dimens with elements initialized to zero.
    */
-  boost::python::numeric::array makeNum(std::vector<int> dimens, 
+  pyndarray makeNum(std::vector<int> dimens, 
 					PyArray_TYPES t);
 				      
   /** 
@@ -72,11 +79,11 @@ namespace num_util{
    *@return a numpy array of size n with elements initialized to data.
    */
 
-  template <typename T> boost::python::numeric::array makeNum(T* data, int n = 0){
+  template <typename T> pyndarray makeNum(T* data, int n = 0){
     boost::python::object obj(boost::python::handle<>(PyArray_FromDims(1, &n, getEnum<T>())));
     void *arr_data = PyArray_DATA((PyArrayObject*) obj.ptr());
     memcpy(arr_data, data, PyArray_ITEMSIZE((PyArrayObject*) obj.ptr()) * n); // copies the input data to 
-    return boost::python::extract<boost::python::numeric::array>(obj);
+    return boost::python::extract<pyndarray>(obj);
   }
 
   /** 
@@ -89,12 +96,12 @@ namespace num_util{
    */
 
 
-  template <typename T> boost::python::numeric::array makeNum(T * data, std::vector<int> dims){
+  template <typename T> pyndarray makeNum(T * data, std::vector<int> dims){
     int total = std::accumulate(dims.begin(),dims.end(),1,std::multiplies<int>());
     boost::python::object obj(boost::python::handle<>(PyArray_FromDims(dims.size(),&dims[0], getEnum<T>())));
     void *arr_data = PyArray_DATA((PyArrayObject*) obj.ptr());
     memcpy(arr_data, data, PyArray_ITEMSIZE((PyArrayObject*) obj.ptr()) * total);
-    return boost::python::extract<boost::python::numeric::array>(obj);
+    return boost::python::extract<pyndarray>(obj);
   }
     
 
@@ -103,15 +110,15 @@ namespace num_util{
    *@param arr a Boost/Python numeric array.
    *@return a numeric array referencing the input array.
    */
-  boost::python::numeric::array makeNum(const 
-					boost::python::numeric::array& arr);
+  pyndarray makeNum(const 
+					pyndarray& arr);
 
   /** 
    *A free function that retrieves the numpy type of a numpy array.
    *@param arr a Boost/Python numeric array.
    *@return the numpy type of the array's elements 
    */
-  PyArray_TYPES type(boost::python::numeric::array arr);
+  PyArray_TYPES type(pyndarray arr);
 
   /** 
    *Throws an exception if the actual array type is not equal to the expected 
@@ -120,7 +127,7 @@ namespace num_util{
    *@param expected_type an expected numpy type.
    *@return -----
    */
-  void check_type(boost::python::numeric::array arr, 
+  void check_type(pyndarray arr, 
 		  PyArray_TYPES expected_type);
 
   /** 
@@ -128,7 +135,7 @@ namespace num_util{
    *@param arr a Boost/Python numeric array.
    *@return an integer that indicates the rank of an array.
    */
-  int rank(boost::python::numeric::array arr);
+  int rank(pyndarray arr);
 
   /** 
    *Throws an exception if the actual rank is not equal to the expected rank.
@@ -136,14 +143,14 @@ namespace num_util{
    *@param expected_rank an expected rank of the numeric array.
    *@return -----
    */
-  void check_rank(boost::python::numeric::array arr, int expected_rank);
+  void check_rank(pyndarray arr, int expected_rank);
   
   /** 
    *A free function that returns the total size of the array.
    *@param arr a Boost/Python numeric array.
    *@return an integer that indicates the total size of the array.
    */
-  int size(boost::python::numeric::array arr);
+  int size(pyndarray arr);
   
   /** 
    *Throw an exception if the actual total size of the array is not equal to 
@@ -152,14 +159,14 @@ namespace num_util{
    *@param expected_size the expected size of an array.
    *@return -----
    */
-  void check_size(boost::python::numeric::array arr, int expected_size);
+  void check_size(pyndarray arr, int expected_size);
 
   /** 
    *Returns the dimensions in a vector.
    *@param arr a Boost/Python numeric array.
    *@return a vector with integer values that indicates the shape of the array.
   */
-  std::vector<int> shape(boost::python::numeric::array arr);
+  std::vector<int> shape(pyndarray arr);
 
   /**
    *Returns the size of a specific dimension.
@@ -167,7 +174,7 @@ namespace num_util{
    *@param dimnum an integer that identifies the dimension to retrieve.
    *@return the size of the requested dimension.
    */
-  int get_dim(boost::python::numeric::array arr, int dimnum);
+  int get_dim(pyndarray arr, int dimnum);
 
   /** 
    *Throws an exception if the actual dimensions of the array are not equal to
@@ -176,7 +183,7 @@ namespace num_util{
    *@param expected_dims an integer vector of expected dimension.
    *@return -----
    */
-  void check_shape(boost::python::numeric::array arr, 
+  void check_shape(pyndarray arr, 
 		   std::vector<int> expected_dims);
 
   /**
@@ -187,28 +194,28 @@ namespace num_util{
    *@param dimsize an expected size of the specified dimension.
    *@return -----
   */
-  void check_dim(boost::python::numeric::array arr, int dimnum, int dimsize);
+  void check_dim(pyndarray arr, int dimnum, int dimsize);
 
   /** 
    *Returns true if the array is contiguous.
    *@param arr a Boost/Python numeric array.
    *@return true if the array is contiguous, false otherwise.
   */
-  bool iscontiguous(boost::python::numeric::array arr);
+  bool iscontiguous(pyndarray arr);
 
   /** 
    *Throws an exception if the array is not contiguous.
    *@param arr a Boost/Python numeric array.
    *@return -----
   */
-  void check_contiguous(boost::python::numeric::array arr);
+  void check_contiguous(pyndarray arr);
 
   /** 
    *Returns a pointer to the data in the array.
    *@param arr a Boost/Python numeric array.
    *@return a char pointer pointing at the first element of the array.
    */
-  void* data(boost::python::numeric::array arr);
+  void* data(pyndarray arr);
 
   /** 
    *Copies data into the array.
@@ -216,14 +223,14 @@ namespace num_util{
    *@param new_data a char pointer referencing the new data.
    *@return -----
    */
-  void copy_data(boost::python::numeric::array arr, char* new_data);
+  void copy_data(pyndarray arr, char* new_data);
   
   /** 
    *Returns a clone of this array.
    *@param arr a Boost/Python numeric array.
    *@return a replicate of the Boost/Python numeric array.
    */
-  boost::python::numeric::array clone(boost::python::numeric::array arr);
+  pyndarray clone(pyndarray arr);
   
   /** 
    *Returns a clone of this array with a new type.
@@ -231,7 +238,7 @@ namespace num_util{
    *@param t PyArray_TYPES of the output array.
    *@return a replicate of 'arr' with type set to 't'.
    */
-  boost::python::numeric::array astype(boost::python::numeric::array arr, 
+  pyndarray astype(pyndarray arr, 
 				       PyArray_TYPES t);
 
 
@@ -239,14 +246,14 @@ namespace num_util{
 /*    *@param arr a Boost/Python numeric array. */
 /*    *@return the reference count of the array. */
 
-  int refcount(boost::python::numeric::array arr);
+  int refcount(pyndarray arr);
 
   /** 
    *Returns the strides array in a vector of integer.
    *@param arr a Boost/Python numeric array.
    *@return the strides of an array.
    */
-  std::vector<int> strides(boost::python::numeric::array arr);
+  std::vector<int> strides(pyndarray arr);
 
   /** 
    *Throws an exception if the element of a numpy array is type cast to
@@ -285,6 +292,16 @@ namespace num_util{
    */
   char type2char(PyArray_TYPES t_type);
   
+  #if BOOST_VERSION >= 106500
+  /** 
+   *Converts single character typecode of PyArray_TYPE
+   *to its corresponding numpy dtype.
+   *@param t  single character typecode of PyArray_TYPES.
+   *@return the corresponding numpy dtype.
+   */
+  np::dtype type2dtype(char t);
+  #endif
+
   /** 
    *Coverts a single character typecode to its PyArray_TYPES.
    *@param e_type a PyArray_TYPES typecode in char.

--- a/src/c++/stat.cc
+++ b/src/c++/stat.cc
@@ -46,7 +46,7 @@ bool _nonzero(const unsigned &n, const int *v)
 // calculate clipped mean/rms for array
 template<class T>
 static pair<double, double>
-_stat_nd(numeric::array arr, double _mean, double _threshold)
+_stat_nd(pyndarray arr, double _mean, double _threshold)
 {
   // ensure contiguous memory access by appropriately sorting indices
   vector<int> shape = n::shape(arr);
@@ -118,7 +118,7 @@ _stat_nd(numeric::array arr, double _mean, double _threshold)
 // calculate clipped mean/rms for masked array
 template<class T>
 static pair<double, double>
-_stat_nd_m(numeric::array arr, numeric::array mask, double _mean, double _threshold)
+_stat_nd_m(pyndarray arr, pyndarray mask, double _mean, double _threshold)
 {
   // ensure contiguous memory access by appropriately sorting indices
   vector<int> shape = n::shape(arr);
@@ -201,17 +201,17 @@ _stat_nd_m(numeric::array arr, numeric::array mask, double _mean, double _thresh
 // dispatch calculation to the correct _stat_FOO function
 template<class T>
 static pair<double, double>
-_stat(numeric::array arr, object mask, double _mean, double _threshold)
+_stat(pyndarray arr, object mask, double _mean, double _threshold)
 {
   if (mask.ptr() == Py_None || mask.ptr() == Py_False 
       || npybool_check(mask.ptr(), false))
     return _stat_nd<T>(arr, _mean, _threshold);
   else
-    return _stat_nd_m<T>(arr, extract<numeric::array>(mask), _mean, _threshold);
+    return _stat_nd_m<T>(arr, extract<pyndarray>(mask), _mean, _threshold);
 }
 
 template<class T>
-static object _bstat(numeric::array arr, object mask, double kappa)
+static object _bstat(pyndarray arr, object mask, double kappa)
 {
   #include <iostream>
   const int max_iter = 200;
@@ -232,7 +232,7 @@ static object _bstat(numeric::array arr, object mask, double kappa)
   return boost::python::make_tuple(mean[1], dev[1], mean.back(), dev.back(), cnt);
 }
 
-object bstat(numeric::array arr, object mask, double kappa)
+object bstat(pyndarray arr, object mask, double kappa)
 {
   NPY_TYPES type = n::type(arr);
 
@@ -241,7 +241,7 @@ object bstat(numeric::array arr, object mask, double kappa)
 
   if (mask.ptr() != Py_None && mask.ptr() != Py_False 
       && !npybool_check(mask.ptr(), false)) {
-    numeric::array amask = extract<numeric::array>(mask);
+    pyndarray amask = extract<pyndarray>(mask);
 
     n::check_type(amask, NPY_BOOL);
     int rank = n::rank(arr);

--- a/src/c++/stat.h
+++ b/src/c++/stat.h
@@ -2,7 +2,16 @@
 #define _CBDSM_STAT_H_INCLUDED_
 
 #include <boost/python.hpp>
+#include <numpy/arrayobject.h>
 
+#if BOOST_VERSION < 106500
+  typedef typename boost::python::pyndarray pyndarray;
+  //namespace np = boost::python::numeric;
+#else
+  #include <boost/python/numpy.hpp>
+  typedef typename boost::python::numpy::ndarray pyndarray;
+  namespace np = boost::python::numpy;
+#endif
 /*!
   \file stat.h
   
@@ -13,7 +22,7 @@
   Clipped RMS and mean value calculation for numpy array.
 */
 
-boost::python::object bstat (boost::python::numeric::array arr,
+boost::python::object bstat (pyndarray arr,
 			     boost::python::object mask,
 			     double kappa);
 


### PR DESCRIPTION
Add support for Boost 1.65 and above, because boost/python/numeric.hpp has een removed from Boost version 1.65 and above.