### PR TITLE
fix append image FITS header into catalog FITS header

### DIFF
--- a/bdsf/output.py
+++ b/bdsf/output.py
@@ -452,7 +452,7 @@ def write_fits_list(img, filename=None, sort_by='index', objtype='gaul',
         tbhdu.header['EQUINOX'] = (img.equinox, 'Equinox')
 
     for key in img.header.keys():
-        if key=="HISTORY": continue
+        if key in ['HISTORY','COMMENT','']: continue
         tbhdu.header['I_%s'%key]=img.header[key]
 
     if filename is None:


### PR DESCRIPTION
Appending image FITS header into catalog FITS header (commit 3fb305ee31453cf96c39579aa28afa39fb5e4363) breaks when there are also blank or comment keywords  -- don't append these