### PR TITLE
Fix name collision of std::list and boost::python::list

### DIFF
--- a/src/c++/MGFunction1.cc
+++ b/src/c++/MGFunction1.cc
@@ -22,7 +22,6 @@ parameters coming to/from python side.
 #include <num_util/num_util.h>
 #include <cfloat>
 
-using namespace std;
 namespace n = num_util;
 
 
@@ -76,14 +75,14 @@ void MGFunction::py_add_gaussian(Gtype type, object parameters)
   py_assert(len(parameters) == 6,
 	    PyExc_ValueError, "Wrong number of parameters for gaussian");
 
-  vector<double> t(6);
+  std::vector<double> t(6);
   for (int i = 0; i < 6; ++i)
     t[i] = extract<double>(parameters[i]);
 
   m_npar += int(type);
   m_gaul.push_back(int(type));
   m_parameters.push_back(t);
-  m_errors.push_back(vector<double>(6));
+  m_errors.push_back(std::vector<double>(6));
 }
 
 //
@@ -114,7 +113,7 @@ boost::python::tuple MGFunction::py_get_gaussian(int idx)
   py_assert(idx >= 0 && idx < (int)m_gaul.size(),
 	    PyExc_IndexError, "Incorrect index");
 
-  vector<double> &p = m_parameters[idx];
+  std::vector<double> &p = m_parameters[idx];
 
   return boost::python::make_tuple(p[0], p[1], p[2], p[3], p[4], p[5]);
 }
@@ -170,7 +169,7 @@ list MGFunction::py_get_errors()
   list res;
 
   for (unsigned i = 0; i < m_gaul.size(); ++i) {
-    vector<double> &e = m_errors[i];
+    std::vector<double> &e = m_errors[i];
     res.append(boost::python::make_tuple(e[0], e[1], e[2], e[3], e[4], e[5]));
   }
 
@@ -182,7 +181,7 @@ list MGFunction::py_get_errors()
 //
 boost::python::tuple MGFunction::py_find_peak()
 {
-  vector<double> buf(data_size());
+  std::vector<double> buf(data_size());
   fcn_diff(&buf.front());
 
   double peak = buf[0];

--- a/src/c++/MGFunction2.cc
+++ b/src/c++/MGFunction2.cc
@@ -44,11 +44,10 @@ and parameters under exponents (NL_ij) are non-linear.
 #if not(defined(_LIBCPP_VERSION)) and __cplusplus <= 199711L
 using namespace __gnu_cxx;
 #endif
-using namespace std;
 namespace n = num_util;
 
-vector<MGFunction::dcache_t> MGFunction::mm_data;
-vector<MGFunction::fcache_t> MGFunction::mm_fcn;
+std::vector<MGFunction::dcache_t> MGFunction::mm_data;
+std::vector<MGFunction::fcache_t> MGFunction::mm_fcn;
 void * MGFunction::mm_obj = 0;
 unsigned long MGFunction::mm_cksum = -1;
 static const double deg = M_PI/180;
@@ -217,7 +216,7 @@ void MGFunction::fcn_gradient(double *buf) const
   fcache_it f = mm_fcn.begin();
   for (unsigned didx = 0; didx < m_ndata; ++didx)
     for (unsigned gidx = 0; gidx < m_gaul.size(); ++gidx, ++f) {
-      const vector<double> &p = m_parameters[gidx];
+      const std::vector<double> &p = m_parameters[gidx];
       double cs = f->cs;
       double sn = f->sn;
       double f1 = f->f1;
@@ -253,7 +252,7 @@ void MGFunction::fcn_diff_gradient(double *buf) const
   fcache_it f = mm_fcn.begin();
   for (unsigned didx = 0; didx < m_ndata; ++didx)
     for (unsigned gidx = 0; gidx < m_gaul.size(); ++gidx, ++f) {
-      const vector<double> &p = m_parameters[gidx];
+      const std::vector<double> &p = m_parameters[gidx];
       double cs = f->cs;
       double sn = f->sn;
       double f1 = f->f1;
@@ -295,7 +294,7 @@ void MGFunction::fcn_transposed_gradient(double *buf) const
   for (didx = 0; didx < m_ndata; ++didx) {
     ggidx = 0;
     for (gidx = 0; gidx < m_gaul.size(); ++gidx, ++f) {
-      const vector<double> &p = m_parameters[gidx];
+      const std::vector<double> &p = m_parameters[gidx];
       double cs = f->cs;
       double sn = f->sn;
       double f1 = f->f1;
@@ -334,7 +333,7 @@ void MGFunction::fcn_diff_transposed_gradient(double *buf) const
   for (didx = 0; didx < m_ndata; ++didx) {
     ggidx = 0;
     for (gidx = 0; gidx < m_gaul.size(); ++gidx, ++f) {
-      const vector<double> &p = m_parameters[gidx];
+      const std::vector<double> &p = m_parameters[gidx];
       double cs = f->cs;
       double sn = f->sn;
       double f1 = f->f1;
@@ -378,7 +377,7 @@ void MGFunction::fcn_partial_gradient(double *buf) const
   for (didx = 0; didx < m_ndata; ++didx) {
     ggidx = 0;
     for (gidx = 0; gidx < m_gaul.size(); ++gidx, ++f) {
-      const vector<double> &p = m_parameters[gidx];
+      const std::vector<double> &p = m_parameters[gidx];
       double cs = f->cs;
       double sn = f->sn;
       double f1 = f->f1;
@@ -456,7 +455,7 @@ void MGFunction::__update_dcache() const
 {
   PyObject *data = (PyObject *)m_data.ptr();
   PyObject *mask = (PyObject *)m_mask.ptr();
-  vector<int> shape = n::shape(m_data);
+  std::vector<int> shape = n::shape(m_data);
   dcache_t t;
 
   mm_data.clear();
@@ -518,7 +517,7 @@ void MGFunction::_update_fcache() const
     fcache_it f = mm_fcn.begin();
     for (dcache_it d = mm_data.begin(); d != mm_data.end(); ++d)
       for (unsigned gidx = 0; gidx < ngaul; ++gidx, ++f) {
-	const vector<double> &p = m_parameters[gidx];
+	const std::vector<double> &p = m_parameters[gidx];
 	int x1 = d->x1;
 	int x2 = d->x2;
 	double cs = cos(p[5]*deg);


### PR DESCRIPTION
Compiling on arch linux with boost 1.67 and gcc 8.1.1 I got a compilation error because of a namespace collision on `list`, solved by removing `using namespace std`.