### PR TITLE
Initialize numpy to avoid segfault in Gaussian fitting (issue #63)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -126,14 +126,13 @@ def find_boost_numpy():
 
     elif system == 'Darwin':
         if sys.version_info[0] == 2:
-            boost_python = "boost_numpy-mt"
+            boost_numpy = "boost_numpy-mt"
         else:
-            boost_python = "boost_numpy3-mt"
+            boost_numpy = "boost_numpy3-mt"
 
         if not find_library(boost_numpy):
             return None
-
-    return boost_python
+        return boost_numpy
 
 
 def main():

--- a/src/c++/cbdsm_main.cc
+++ b/src/c++/cbdsm_main.cc
@@ -1,8 +1,8 @@
 /*!
   \file cbdsm_main.cc
-  
+
   \ingroup pybdsm
-  
+
   \author Oleksandr Usov
 */
 
@@ -20,9 +20,11 @@ BOOST_PYTHON_MODULE(_cbdsm)
   import_array();
   #if BOOST_VERSION < 106500
   numeric::array::set_module_and_type("numpy", "ndarray");
+  #else
+  boost::python::numpy::initialize();
   #endif
-  
-  scope().attr("__doc__") = 
+
+  scope().attr("__doc__") =
     "A collection of optimized C & Fortran routines for pybdsm";
 
   def("bstat", &bstat, (arg("array"), arg("mask") = false, arg("kappa") = 3),


### PR DESCRIPTION
The hanging described in issue #63 seems to be caused by a segfault due to numpy not being initialized. This PR fixes it on my test system.