### PR TITLE
Installation without using conda (Readme update)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,9 @@ External requirements include the ubuntu packages (or similar packages in anothe
 Also, a working ``numpy`` installation is required.
 At runtime, you will need ``scipy`` and either ``pyfits`` and ``pywcs`` or ``python-casacore`` or ``astropy``.
 
-If you install as a user not using conda, use ``pip install --user``.
+If you install as a user not using conda, use ``pip install --user``. 
+Make sure to use similar versions for gcc, g++ and gfortran 
+(use update-alternatives if multiple versions of gcc/g++/gfortran are present on the system). 
 In this case, the script ``pybdsf`` is installed in ``~/.local/bin``, so you might want to add that to your ``$PATH``.
 
 Installation on MacOS / OSX is more involved, you will need the packages mentioned above, for example installed with Homebrew.


### PR DESCRIPTION
I faced installation issues for PyBDSF on Ubuntu 16.04 in environment without conda. After some lookup, I realized the errors being due to compiler version difference for gcc, g++ (6.5 both) and gfortran(5.5). After using update-alternatives and changing gcc, g++ version to 5.5 (same as gfortran), the installation worked without any issue. I've created a gist for 'update-alternatives' usage [here](https://gist.github.com/kiryteo/e7cb52ecce8c2b25eca6acdd8ddbb5a7).

