### PR TITLE
Fix Travis-CI issue with Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 
 python:
   - 2.7
-  - 3.4
+  - 3.5
 
 before_install:
   - sudo apt-get -qq update

--- a/bdsf/shapelets.py
+++ b/bdsf/shapelets.py
@@ -92,7 +92,10 @@ def shapelet_image(basis, beta, centre, hc, nx, ny, size):
         try:
             from scipy.misc.common import factorial
         except ImportError:
-            from scipy.misc import factorial
+            try:
+                from scipy.misc import factorial
+            except ImportError:
+                from scipy.special import factorial
 
     hcx = hc[nx,:]
     hcy = hc[ny,:]


### PR DESCRIPTION
As suggested by Tammo Jan, changing to Python 3.5 fixed the boost-python issue that occurred with 3.4. 

I also fixed the import of scipy's factorial function.