### PR TITLE
add boost_python3 and numpy_python3 to libnames in find functions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -127,6 +127,7 @@ def find_boost_python():
     boostlibnames = ['boost_python-py' + short_version,
                      'boost_python' + short_version,
                      'boost_python',
+                     'boost_python3'
                      ]
     # The -mt (multithread) extension is used on macOS but not Linux.
     # Look for it first to avoid ending up with a single-threaded version.
@@ -145,6 +146,7 @@ def find_boost_numpy():
     boostlibnames = ['boost_numpy-py' + short_version,
                      'boost_numpy' + short_version,
                      'boost_numpy',
+                     'boost_numpy3'
                      ]
     # The -mt (multithread) extension is used on macOS but not Linux.
     # Look for it first to avoid ending up with a single-threaded version.


### PR DESCRIPTION
solves an issue of PyBDSF not being able to find boost library when using Python3, since boost_python can have a few name variations and these are hard coded into the setup.py file.