### PR TITLE
Use system specific multiarch name instead of x86_64

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -111,8 +111,16 @@ def find_library_file(libname):
     lib_dirs = [os.path.join(sys.prefix, 'lib'),
                              '/usr/local/lib',
                              '/usr/lib64',
-                             '/usr/lib',
-                             '/usr/lib/x86_64-linux-gnu']
+                             '/usr/lib']
+    try:
+        lib_dirs.append(os.path.join('/usr/lib',
+                                    getattr(sys, "implementation", sys)
+                                    ._multiarch))
+    except AttributeError:  # This is a non-multiarch aware Python.
+        import sysconfig
+        arch = sysconfig.get_config_var('MULTIARCH')
+        if arch is not None:
+            lib_dirs.append(os.path.join('/usr/lib', arch))
 
     if 'LD_LIBRARY_PATH' in os.environ:
         lib_dirs += os.environ['LD_LIBRARY_PATH'].split(':')


### PR DESCRIPTION
The directory `/usr/lib/x86_64-linux-gnu` is obviously very architecture specific. However, `sys.implementation` offers a corresponding variable `_multiarch`, which is used here instead. See also https://wiki.debian.org/Python/MultiArch 
After applying this, PyBDSF [compiles on all out platforms](https://buildd.debian.org/status/logs.php?pkg=pybdsf&ver=1.9.2-2&suite=sid) (MIPS still pending): 