### PR TITLE
has_pyfftw used, but not defined in wavelet_atrous.py

### DIFF
--- a/bdsf/wavelet_atrous.py
+++ b/bdsf/wavelet_atrous.py
@@ -40,8 +40,9 @@ try:
     N.fft.ifftn = pyfftw.interfaces.numpy_fft.ifftn
     scipy.signal.signaltools.fftn = pyfftw.interfaces.scipy_fftpack.fftn
     scipy.signal.signaltools.ifftn = pyfftw.interfaces.scipy_fftpack.ifftn
+    has_pyfftw = True
 except ImportError:
-    pass
+    has_pyfftw = False
 
 
 class Op_wavelet_atrous(Op):


### PR DESCRIPTION
wavelet_atrous.py appears to use a flag 'has_pyfftw' to check if the module pyfftw.interfaces could be imported, but this flag is never set, leading to a NameError as follows: https://pastebin.com/Wz7nwnH3.

Setting it True/False in the try/except block where pyfftw.interfaces is attempted to be imported should address it.

Python: 3.8.6
PyBDSF: 1.9.2