### PR TITLE
Improve handling of beam in spectral index module

### DIFF
--- a/bdsf/gausfit.py
+++ b/bdsf/gausfit.py
@@ -281,7 +281,7 @@ class Op_gausfit(Op):
         verbose = opts.verbose_fitting
         if verbose:
             print('Entering fit_island in verbose mode')
-        
+
         if ffimg is None:
             fit_image = isl.image-isl.islmean
         else:

--- a/bdsf/opts.py
+++ b/bdsf/opts.py
@@ -798,12 +798,12 @@ class Opts(object):
                                  "is raised. PyBDSF will not work without the "\
                                  "knowledge of the frequency.",
                              group = "multichan_opts")
-    beam_sp_derive = Bool(False,
+    beam_sp_derive = Bool(True,
                              doc = "If True and beam_spectrum is None, then "\
-                                 "assume header beam is for median frequency and scales "\
+                                 "assume header beam is for lowest frequency and scales "\
                                  "with frequency for channels\n"\
                                  "If True and the parameter beam_spectrum is None, then "\
-                                 "we assume that the beam in the header is for the median "\
+                                 "we assume that the beam in the header is for the lowest "\
                                  "frequency of the image cube and scale accordingly to "\
                                  "calculate the beam per channel. If False, then a "\
                                  "constant value of the beam is taken instead.",

--- a/doc/source/process_image.rst
+++ b/doc/source/process_image.rst
@@ -825,8 +825,8 @@ The options concerning multichannel images are:
 .. parsed-literal::
 
     multichan_opts ........ True : Show options for multi-channel images
-      :term:`beam_sp_derive` ..... False : If True and beam_spectrum is None, then assume
-                                   header beam is for median frequency and scales
+      :term:`beam_sp_derive` ...... True : If True and beam_spectrum is None, then assume
+                                   header beam is for lowest frequency and scales
                                    with frequency for channels
       :term:`beam_spectrum` ....... None : FWHM of synthesized beam per channel. Specify as
                                    [(bmaj_ch1, bmin_ch1, bpa_ch1), (bmaj_ch2,
@@ -850,10 +850,10 @@ The options concerning multichannel images are:
 .. glossary::
 
     beam_sp_derive
-        This parameter is a Boolean (default is ``False``). If `True` and the parameter beam_spectrum is ``None``, then we assume that the
-        beam in the header is for the median frequency of the image cube and
+        This parameter is a Boolean (default is ``True``). If `True` and the parameter beam_spectrum is ``None`` and no channel-dependent beam parameters are found in the header, then we assume that the
+        beam in the header is for the lowest frequency of the image cube and
         scale accordingly to calculate the beam per channel. If ``False``, then a
-        constant value of the beam is taken instead.
+        constant value of the beam (that given in the header or specified with the ``beam`` parameter) is taken instead.
 
     beam_spectrum
         This parameter is a list of tuples (default is ``None``) that sets the FWHM of synthesized beam per channel. Specify as [(bmaj_ch1, bmin_ch1,
@@ -861,9 +861,9 @@ The options concerning multichannel images are:
         ``beam_spectrum = [(0.01, 0.01, 45.0), (0.02, 0.01, 34.0)]`` for two
         channels.
 
-        If ``None``, then the channel-dependent restoring beam is either assumed to
-        be a constant or to scale with frequency, depending on whether the
-        parameter ``beam_sp_derive`` is ``False`` or ``True``.
+        If ``None``, then the channel-dependent restoring beam is searched for in the header.
+        If not found, the beam is either assumed to be a constant or to scale with frequency,
+        depending on whether the parameter ``beam_sp_derive`` is ``False`` or ``True``.
 
     collapse_av
         This parameter is a list of integers (default is ``[]``) that specifies the channels to be averaged to produce the


### PR DESCRIPTION
This PR improves the handling of the beam when the beam_spectrum option is set to None by searching the header for the beam sizes or by scaling the size with frequency. Previously, no scaling was done.