### PR TITLE
Build binary wheels for Python 3.8 and 3.9

### DIFF
--- a/manylinux2010/build.sh
+++ b/manylinux2010/build.sh
@@ -3,7 +3,7 @@
 HERE=`dirname "$0"`
 cd $HERE/..
 
-for i in 37 27 34 35 36; do
+for i in 36 37 38 39; do
     docker build -f manylinux2010/wheel${i}.docker . -t pybdsf${i}
     docker run -v `pwd`/manylinux2010:/manylinux2010 pybdsf${i} sh -c "cp /output/*.whl /manylinux2010/."
 done

--- a/manylinux2010/wheel38.docker
+++ b/manylinux2010/wheel38.docker
@@ -14,10 +14,9 @@ WORKDIR /build
 # how many threads to use for compiling
 ENV THREADS 4
 
-ENV PYMAJOR 2
-ENV PYMINOR 7
-ENV PYUNICODE mu
-ENV TARGET cp${PYMAJOR}${PYMINOR}-cp${PYMAJOR}${PYMINOR}${PYUNICODE}
+ENV PYMAJOR 3
+ENV PYMINOR 8
+ENV TARGET cp${PYMAJOR}${PYMINOR}-cp${PYMAJOR}${PYMINOR}
 
 # install python dependencies, make boost install also boost_numpy
 RUN /opt/python/${TARGET}/bin/pip install numpy

--- a/manylinux2010/wheel39.docker
+++ b/manylinux2010/wheel39.docker
@@ -15,9 +15,8 @@ WORKDIR /build
 ENV THREADS 4
 
 ENV PYMAJOR 3
-ENV PYMINOR 5
-ENV PYUNICODE m
-ENV TARGET cp${PYMAJOR}${PYMINOR}-cp${PYMAJOR}${PYMINOR}${PYUNICODE}
+ENV PYMINOR 9
+ENV TARGET cp${PYMAJOR}${PYMINOR}-cp${PYMAJOR}${PYMINOR}
 
 # install python dependencies, make boost install also boost_numpy
 RUN /opt/python/${TARGET}/bin/pip install numpy


### PR DESCRIPTION
Added support for building binary wheels for Python 3.8 and 3.9. Removed support for Python 2.7, 3.4 and 3.5, because these version are obsolete and no longer supported by `manylinux2010`.