### PR TITLE
Replace private scipy function

### DIFF
--- a/bdsf/functions.py
+++ b/bdsf/functions.py
@@ -533,18 +533,18 @@ def std(y):
 def imageshift(image, shift):
     """ Shifts a 2d-image by the tuple (shift). Positive shift is to the right and upwards.
     This is done by fourier shifting. """
-    import scipy
+    import scipy.fft
     from scipy import ndimage
 
     shape=image.shape
 
-    f1=scipy.fft(image, shape[0], axis=0)
-    f2=scipy.fft(f1, shape[1], axis=1)
+    f1=scipy.fft.fft(image, shape[0], axis=0)
+    f2=scipy.fft.fft(f1, shape[1], axis=1)
 
     s=ndimage.fourier_shift(f2,shift, axis=0)
 
-    y1=scipy.ifft(s, shape[1], axis=1)
-    y2=scipy.ifft(y1, shape[0], axis=0)
+    y1=scipy.fft.ifft(s, shape[1], axis=1)
+    y2=scipy.fft.ifft(y1, shape[0], axis=0)
 
     return y2.real
 
@@ -2252,3 +2252,19 @@ def bstat(indata, mask, kappa_npixbeam):
     r = numpy.sqrt(sigma**2 * (r1 / (r1 - 2.0*kappa*numpy.exp(-kappa**2/2.0))))
 
     return m_raw, r_raw, m, r, iter
+
+
+def centered(arr, newshape):
+    """Return the center newshape portion of the array
+
+    This function is a copy of the private _centered() function in
+    scipy.signal.signaltools
+    """
+    import numpy as np
+
+    newshape = np.asarray(newshape)
+    currshape = np.array(arr.shape)
+    startind = (currshape - newshape) // 2
+    endind = startind + newshape
+    myslice = [slice(startind[k], endind[k]) for k in range(len(endind))]
+    return arr[tuple(myslice)]

--- a/bdsf/wavelet_atrous.py
+++ b/bdsf/wavelet_atrous.py
@@ -19,7 +19,6 @@ from . import functions as func
 import gc
 from numpy import array, product
 import scipy.signal
-from scipy.signal.signaltools import _centered
 from .readimage import Op_readimage
 from .preprocess import Op_preprocess
 from .rmsimage import Op_rmsimage
@@ -562,9 +561,9 @@ def fftconvolve(in1, in2, mode="full", pad_to_power_of_two=True, numcores=1):
             osize = s1
         else:
             osize = s2
-        return _centered(ret, osize)
+        return func.centered(ret, osize)
     elif mode == "valid":
-        return _centered(ret, abs(s2 - s1) + 1)
+        return func.centered(ret, abs(s2 - s1) + 1)
 
 
 def rebase_bbox(box,minv):


### PR DESCRIPTION
This PR provides a replacement for the private `_centered()` function from scipy that is no longer available (see issue #171). It also updates the `fft()` and `ifft()` calls used by the PSF variation module.