### PR TITLE
Use len() instead of np.alen().

### DIFF
--- a/bdsf/rmsimage.py
+++ b/bdsf/rmsimage.py
@@ -856,7 +856,7 @@ class Op_rmsimage(Op):
 
                 cutout = themap[x1:x2, y1:y2].ravel()
                 goodcutout = cutout[cutout != magic]
-                num_unmasked = N.alen(goodcutout)
+                num_unmasked = len(goodcutout)
                 if num_unmasked > 0:
                     themap[x, y] = N.nansum(goodcutout)/float(len(goodcutout))
                 delx += 1


### PR DESCRIPTION
np.alen() has been removed from NumPy v1.23.

see https://numpy.org/doc/stable/release/1.23.0-notes.html?highlight=alen#expired-deprecations