### PR TITLE
Add binary wheels for Python 3.10

### DIFF
--- a/manylinux2010/build.sh
+++ b/manylinux2010/build.sh
@@ -3,7 +3,7 @@
 HERE=`dirname "$0"`
 cd $HERE/..
 
-for i in 36 37 38 39; do
+for i in 36 37 38 39 310; do
     docker build -f manylinux2010/wheel${i}.docker . -t pybdsf${i}
     docker run -v `pwd`/manylinux2010:/manylinux2010 pybdsf${i} sh -c "cp /output/*.whl /manylinux2010/."
 done

--- a/manylinux2010/wheel310.docker
+++ b/manylinux2010/wheel310.docker
@@ -1,0 +1,43 @@
+FROM quay.io/pypa/manylinux2010_x86_64
+
+
+# install rpms
+RUN yum install -y gcc-gfortran
+
+# download other source code
+WORKDIR /tmp
+RUN curl https://ufpr.dl.sourceforge.net/project/boost/boost/1.76.0/boost_1_76_0.tar.bz2 --output /tmp/boost.tar.bz2
+
+RUN mkdir /build
+WORKDIR /build
+
+# how many threads to use for compiling
+ENV THREADS 4
+
+ENV PYMAJOR 3
+ENV PYMINOR 10
+ENV TARGET cp${PYMAJOR}${PYMINOR}-cp${PYMAJOR}${PYMINOR}
+
+# install python dependencies, make boost install also boost_numpy
+RUN /opt/python/${TARGET}/bin/pip install oldest-supported-numpy
+
+# setup boost
+WORKDIR /build
+RUN tar jxf /tmp/boost.tar.bz2
+WORKDIR /build/boost_1_76_0
+RUN ./bootstrap.sh --prefix=/opt/boost \
+    --with-libraries=python \
+    --with-python=/opt/python/${TARGET}/bin/python \
+    --with-python-version=${PYMAJOR}.${PYMINOR} \
+    --with-python-root=/opt/python/${TARGET}
+RUN ./b2 -j${THREADS} \
+    cxxflags="-fPIC -I/opt/python/${TARGET}/include/python${PYMAJOR}.${PYMINOR}${PYUNICODE}/" \
+    link=static,shared install
+
+ADD . /PyBDSF
+WORKDIR /PyBDSF
+ENV CFLAGS "-I/opt/boost/include -L/opt/boost/lib"
+ENV LD_LIBRARY_PATH "/opt/boost/lib:/usr/local/lib"
+RUN /opt/python/${TARGET}/bin/python ./setup.py build_ext -j${THREADS}
+RUN /opt/python/${TARGET}/bin/python ./setup.py bdist_wheel -d .
+RUN auditwheel repair --plat manylinux2010_x86_64 -w /output *.whl


### PR DESCRIPTION
And bump Boost version to fix removal of deprecated function: https://github.com/boostorg/python/pull/344

I've only bumped the Boost version in the Python 3.10 build, one question would be whether that should be updated for all build wheels.