### PR TITLE
Fix ImportError in setuptools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
 [build-system]
-requires = ["setuptools", 
+requires = ["setuptools<65.6",
             "wheel", 
             "oldest-supported-numpy"]


### PR DESCRIPTION
Most recent changes to `setuptools` break compatibility with `numpy.distutils`, resulting in the following error:
```
ImportError: cannot import name 'Log' from 'distutils.log' (/tmp/pip-build-env-ewbr2q8n/overlay/lib/python3.8/site-packages/setuptools/_distutils/log.py)
```
See https://github.com/numpy/numpy/issues/22623 for more details.

This commit fixes issue #189.