### PR TITLE
Fix #198

### DIFF
--- a/bdsf/plotresults.py
+++ b/bdsf/plotresults.py
@@ -247,7 +247,12 @@ def plotresults(img, ch0_image=True, rms_image=True, mean_image=True,
         numx = 1
     numy = int(N.ceil(float(len(images))/float(numx)))
     fig = pl.figure(figsize=(max(15, 10.0*float(numy)/float(numx)), 10.0))
-    fig.canvas.set_window_title('PyBDSM Fit Results for '+ img.filename)
+    try:
+        # This way has been deprecated with Matplotlib 3.4.
+        fig.canvas.set_window_title('PyBDSM Fit Results for '+ img.filename)
+    except AttributeError:
+        # We are on a newer Matplotlib where the above is deprecated.
+        fig.canvas.manager.set_window_title('PyBDSM Fit Results for '+ img.filename)
     gray_palette = cm.gray
     gray_palette.set_bad('k')
 


### PR DESCRIPTION
Fixes #198 by first trying the old method and if that fails trying the updated call to `canvas.manager.set_window_title` instead of `canvas.set_window_title`.