### PR TITLE
Fix build issue with Python 3.11

### DIFF
--- a/manylinux2014/build.sh
+++ b/manylinux2014/build.sh
@@ -8,7 +8,7 @@ SCRIPT_DIR=$(cd $(dirname $0) && pwd)
 ROOT_DIR=$(git rev-parse --show-toplevel)
 
 py_major=3
-for py_minor in $(seq 6 10); do
+for py_minor in $(seq 6 11); do
     echo -e "\n\n******** Building wheel for python ${py_major}.${py_minor} ********\n"
     py_version=${py_major}${py_minor}
     [ ${py_minor} -le 7 ] && py_unicode="m" || py_unicode=

--- a/manylinux2014/py_wheel.docker
+++ b/manylinux2014/py_wheel.docker
@@ -18,9 +18,9 @@ RUN /opt/python/${TARGET}/bin/pip install oldest-supported-numpy "setuptools<65.
 
 # download and build boost
 WORKDIR /build
-RUN curl https://ufpr.dl.sourceforge.net/project/boost/boost/1.76.0/boost_1_76_0.tar.bz2 --output boost.tar.bz2
+RUN curl https://ufpr.dl.sourceforge.net/project/boost/boost/1.81.0/boost_1_81_0.tar.bz2 --output boost.tar.bz2
 RUN tar jxf boost.tar.bz2
-WORKDIR /build/boost_1_76_0
+WORKDIR /build/boost_1_81_0
 RUN ./bootstrap.sh --prefix=/opt/boost \
     --with-libraries=python \
     --with-python=/opt/python/${TARGET}/bin/python \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,10 +9,10 @@ requires = [
 [tool.cibuildwheel]
 before-all = "cibuildwheel/before_all.sh"
 before-build = "cibuildwheel/before_build.sh"
-build = "cp3{7,8,9,10}-*_x86_64"
+build = "cp3{7,8,9,10,11}-*_x86_64"
 build-verbosity = 1
 environment = """ \
-    BOOST_VERSION="1.76.0" \
+    BOOST_VERSION="1.81.0" \
     BOOST_BUILD_DIR="/tmp/boost-build" \
     BOOST_INSTALL_DIR="${HOME}/boost" \
     CC=gcc \

--- a/setup.py
+++ b/setup.py
@@ -204,8 +204,8 @@ def main():
     fext = Extension(
         name="bdsf._pytesselate",
         sources=[
-            "src/fortran/pytess_simple.f",
-            "src/fortran/pytess_roundness.f"
+            "src/fortran/pytess_roundness.f",
+            "src/fortran/pytess_simple.f"
         ]
     )
     fext.f2py_options = [""]

--- a/setup.py
+++ b/setup.py
@@ -266,6 +266,7 @@ def main():
             'Programming Language :: Python :: 3.8',
             'Programming Language :: Python :: 3.9',
             'Programming Language :: Python :: 3.10',
+            'Programming Language :: Python :: 3.11',
             'Topic :: Scientific/Engineering :: Astronomy'
         ],
         ext_modules=extensions,

--- a/src/fortran/pytess_roundness.f
+++ b/src/fortran/pytess_roundness.f
@@ -67,8 +67,8 @@ c! if code='s' then each pt belongs to one bin. If not then fuzzy tesselation
      /                 (j-ygens(k))*(j-ygens(k)))/wts
            if (dist.lt.dumr) then
             dumr=dist
-            minind(i,j)=k
-           end if               ! minind(i,j) is number of nearest generator
+            minind(i,j)=k       ! minind(i,j) is number of nearest generator
+           end if
           end do
          end do
         end do

--- a/src/fortran/pytess_simple.f
+++ b/src/fortran/pytess_simple.f
@@ -22,13 +22,13 @@ cf2py   intent(out) volrank
      /               (j-ygens(k))*(j-ygens(k)))/wts(k)
            if (dist.lt.dumr) then
             dumr=dist
-            minind(i,j)=k
-           end if               ! minind(i,j) is number of nearest generator
+            minind(i,j)=k       ! minind(i,j) is number of nearest generator
+           end if
           end do
          end do
-        end do      
+        end do
 c!
-        if (code.eq.'s') then   
+        if (code.eq.'s') then
          do j=1,m
           do i=1,n
            volrank(i,j)=1.d0*minind(i,j)
@@ -46,7 +46,7 @@ c!
      /                    (j-ygens(l))*(j-ygens(l)))/wts(l)
              if (dist.le.(1.d0+eps)*distmin)
      /           volrank(i,j)=volrank(i,j)+1.d0*(l+k)
-            end if           
+            end if
            end do
           end do
          end do


### PR DESCRIPTION
The Python 3.11 build failed, due to some obscure error generated by `f2py`. 

Further investigation showed that the problem is caused by a bug in `f2py.crackfortran`: see https://github.com/numpy/numpy/issues/23533 (BUG: f2py.crackfortran fails on comment after endif statement). The quick work-around was to fix the affected Fortran files.

After that fix, it turned out that the self test failed. This could be tracked down to a problem with Boost and Python 3.11: see https://github.com/boostorg/python/issues/400 (Python 3.11 gives SystemError: type Boost.Python.enum has the Py_TPFLAGS_HAVE_GC flag but has no traverse function). Bumping the Boost version to 1.81 resolved this issue.

Fixes #189