### PR TITLE
Fix issues with error estimation

### DIFF
--- a/bdsf/functions.py
+++ b/bdsf/functions.py
@@ -793,7 +793,7 @@ def get_errors(img, p, stdav, bm_pix=None):
         dumrr2 = 1.0 + bm_pix[0] * bm_pix[1] / (size[1] * size[1])
         dumrr3 = dumr * pp[0] / stdav
         d1 = sqrt(8.0 * log(2.0))
-        d2 = (size[0] * size[0] - size[1] * size[1]) / (size[0] * size[0])
+        d2 = (size[0] * size[0] - size[1] * size[1]) / (size[0] * size[1])
         try:
             e_peak = pp[0] * sq2 / (dumrr3 * pow(dumrr1, 0.75) * pow(dumrr2, 0.75))
             e_maj = size[0] * sq2 / (dumrr3 * pow(dumrr1, 1.25) * pow(dumrr2, 0.25))

--- a/bdsf/functions.py
+++ b/bdsf/functions.py
@@ -753,7 +753,7 @@ def deconv2(gaus_bm, gaus_c):
     return (bmaj, bmin, bpa), ifail
 
 
-def get_errors(img, p, stdav, bm_pix=None):
+def get_errors(img, p, stdav, bm_pix=None, fixed_to_beam=False):
     """ Returns errors from Condon 1997
 
     Returned list includes errors on:
@@ -812,7 +812,17 @@ def get_errors(img, p, stdav, bm_pix=None):
             e_min = 0.0
             e_pa = 0.0
             e_tot = 0.0
-        if abs(e_pa) > 180.0: e_pa=180.0  # dont know why i did this
+        if abs(e_pa) > 180.0:
+            e_pa = 180.0
+        if fixed_to_beam:
+            # When the size was fixed to that of the beam during the fit, set
+            # uncertainties on the size to zero and reduce the error in the fluxes
+            # by sqrt(2) (see Eq. 25 of Condon 1997)
+            e_maj = 0.0
+            e_min = 0.0
+            e_pa = 0.0
+            e_peak /= sq2
+            e_tot /= sq2
         errors = errors + [e_peak, e_x0, e_y0, e_maj, e_min, e_pa, e_tot]
 
     return errors

--- a/bdsf/functions.py
+++ b/bdsf/functions.py
@@ -762,7 +762,7 @@ def get_errors(img, p, stdav, bm_pix=None, fixed_to_beam=False):
     img: Image object (needed for pixel beam info)
     p: list of Gaussian parameters: [peak, x0, y0, maj, min, pa, tot]
     stdav: estimate of the image noise at the Gaussian's position
-    bm_pix: optional pixel beam to used instead of that in img
+    bm_pix: optional pixel beam to be used instead of that in img
     fixed_to_beam: True if the fits were done with the
         size fixed to that of the beam, False otherwise
 

--- a/bdsf/functions.py
+++ b/bdsf/functions.py
@@ -2356,3 +2356,15 @@ def set_up_output_paths(opts):
                            "write permission using the 'outdir' option.".format(output_basedir))
 
     return parentname, output_basedir
+
+def fix_gaussian_axes(major, minor, pa):
+    """Check a Gaussian for switched axes and fix if found
+
+    Returns corrected (major, minor, pa)
+    """
+    if major < minor:
+        major, minor = minor, major
+        pa += 90.0
+    pa = divmod(pa, 180)[1]  # restrict to range [0, 180)
+
+    return (major, minor, pa)

--- a/bdsf/gausfit.py
+++ b/bdsf/gausfit.py
@@ -1023,9 +1023,9 @@ class Gaussian(object):
                 func.approx_equal(size[2], img.pixel_beam()[2]+90.0) or \
                 img.opts.fix_to_beam:
             # Check whether fitted Gaussian is just the distorted pixel beam given as an
-            # initial guess (i.e., [bm_maj*1.1, bm_min, bm_pa+90]) or if size was fixed to
-            # the beam. If so, reset the size to the undistorted beam. Note: these are
-            # sigma sizes, not FWHM sizes.
+            # initial guess (always set to [bm_maj*1.1, bm_min, bm_pa+90]) or if size was
+            # fixed to the beam. If so, reset the size to the undistorted beam. Note:
+            # these are sigma sizes, not FWHM sizes.
             size = img.pixel_beam()
             size = (size[0], size[1], size[2]+90.0) # adjust angle so that corrected_size() works correctly
         size = func.corrected_size(size)  # gives fwhm and P.A.

--- a/bdsf/gausfit.py
+++ b/bdsf/gausfit.py
@@ -1048,13 +1048,13 @@ class Gaussian(object):
             self.centre_skyE = img.pix2coord(errors[1:3], self.centre_pix, use_wcs=use_wcs)
             self.size_sky = img.pix2gaus(size, self.centre_pix, use_wcs=use_wcs) # FWHM in degrees and P.A. east from north
             self.size_sky_uncorr = img.pix2gaus(size, self.centre_pix, use_wcs=False) # FWHM in degrees and P.A. east from +y axis
-            self.size_skyE = img.pix2gaus(errors[3:6], self.centre_pix, use_wcs=use_wcs)
-            self.size_skyE_uncorr = img.pix2gaus(errors[3:6], self.centre_pix, use_wcs=False)
+            self.size_skyE = img.pix2gaus(errors[3:6], self.centre_pix, use_wcs=use_wcs, is_error=True)
+            self.size_skyE_uncorr = img.pix2gaus(errors[3:6], self.centre_pix, use_wcs=False, is_error=True)
             gaus_dc, err = func.deconv2(bm_pix, size)
             self.deconv_size_sky = img.pix2gaus(gaus_dc, self.centre_pix, use_wcs=use_wcs)
             self.deconv_size_sky_uncorr = img.pix2gaus(gaus_dc, self.centre_pix, use_wcs=False)
-            self.deconv_size_skyE  = img.pix2gaus(errors[3:6], self.centre_pix, use_wcs=use_wcs)
-            self.deconv_size_skyE_uncorr = img.pix2gaus(errors[3:6], self.centre_pix, use_wcs=False)
+            self.deconv_size_skyE  = img.pix2gaus(errors[3:6], self.centre_pix, use_wcs=use_wcs, is_error=True)
+            self.deconv_size_skyE_uncorr = img.pix2gaus(errors[3:6], self.centre_pix, use_wcs=False, is_error=True)
         else:
             # These are flagged Gaussians, so don't calculate sky values or errors
             errors = [0]*7

--- a/bdsf/gausfit.py
+++ b/bdsf/gausfit.py
@@ -1022,10 +1022,10 @@ class Gaussian(object):
                 func.approx_equal(size[1], img.pixel_beam()[1]) and \
                 func.approx_equal(size[2], img.pixel_beam()[2]+90.0) or \
                 img.opts.fix_to_beam:
-            # Check whether fitted Gaussian is just the distorted pixel beam
-            # given as an initial guess or if size was fixed to the beam. If so,
-            # reset the size to the undistorted beam.
-            # Note: these are sigma sizes, not FWHM sizes.
+            # Check whether fitted Gaussian is just the distorted pixel beam given as an
+            # initial guess (i.e., [bm_maj*1.1, bm_min, bm_pa+90]) or if size was fixed to
+            # the beam. If so, reset the size to the undistorted beam. Note: these are
+            # sigma sizes, not FWHM sizes.
             size = img.pixel_beam()
             size = (size[0], size[1], size[2]+90.0) # adjust angle so that corrected_size() works correctly
         size = func.corrected_size(size)  # gives fwhm and P.A.
@@ -1043,7 +1043,7 @@ class Gaussian(object):
         tot = p[0]*size[0]*size[1]/(bm_pix[0]*bm_pix[1])
         if flg == 0:
             # These are good Gaussians
-            errors = func.get_errors(img, p+[tot], img.islands[isl_idx].rms)
+            errors = func.get_errors(img, p+[tot], img.islands[isl_idx].rms, fixed_to_beam=img.opts.fix_to_beam)
             self.centre_sky = img.pix2sky(p[1:3])
             self.centre_skyE = img.pix2coord(errors[1:3], self.centre_pix, use_wcs=use_wcs)
             self.size_sky = img.pix2gaus(size, self.centre_pix, use_wcs=use_wcs) # FWHM in degrees and P.A. east from north

--- a/bdsf/opts.py
+++ b/bdsf/opts.py
@@ -492,7 +492,13 @@ class Opts(object):
                                  "If True, then during fitting the major and minor axes "\
                                  "and PA of the Gaussians are fixed to the beam. Only the "\
                                  "amplitude and position are fit. If False, all parameters "\
-                                 "are fit.",
+                                 "are fit.\n"\
+                                 "Note that when this option is activated, as a "\
+                                 "consequence of using fewer free parameters, the estimated errors on the "\
+                                 "peak and total flux densities are a factor of sqrt(2) lower "\
+                                 "compared to the case in which all parameters are fit (see "\
+                                 "Condon 1997). Additionally, the reported errors on the major "\
+                                 "and minor axes and the PA are zero.",
                              group = "advanced_opts")
     fittedimage_clip = Float(0.1,
                              doc = "Sigma for clipping Gaussians " \

--- a/bdsf/readimage.py
+++ b/bdsf/readimage.py
@@ -241,7 +241,7 @@ class Op_readimage(Op):
                 transform is desired
             Input beam angle should be degrees CCW from the +y axis of the image.
             The output beam angle is degrees CCW from North.
-            Set is_error = True when x gives the errors on the parameters instead of
+            Set is_error = True when x contains the errors on the parameters instead of
                 the parameters themselves.
             """
             if use_wcs:

--- a/bdsf/readimage.py
+++ b/bdsf/readimage.py
@@ -233,7 +233,7 @@ class Op_readimage(Op):
             else:
                 return img.beam2pix(x)
 
-        def pix2gaus(x, location=None, use_wcs=True):
+        def pix2gaus(x, location=None, use_wcs=True, is_error=False):
             """ Converts Gaussian parameters in pixels to deg.
 
             x - (maj [pix], min [pix], pa [deg])
@@ -251,7 +251,8 @@ class Op_readimage(Op):
                 th_rad = th / 180.0 * N.pi
                 bmaj = self.pixdist2angdist(img, s1, th, location=location)
                 bmin = self.pixdist2angdist(img, s2, th + 90.0, location=location)
-                bpa = th - brot
+                if not is_error:
+                    bpa = th - brot
                 if bmaj < bmin:
                     bmaj, bmin = bmin, bmaj
                     bpa += 90.0

--- a/bdsf/readimage.py
+++ b/bdsf/readimage.py
@@ -335,7 +335,7 @@ class Op_readimage(Op):
 
             Input beam angle should be degrees CCW from the +y axis of the image.
             The output beam angle is degrees CCW from North at image center.
-            Set is_error = True when x gives the errors on the parameters instead of
+            Set is_error = True when x contains the errors on the parameters instead of
                 the parameters themselves.
             """
             s1, s2, th = x

--- a/doc/source/algorithms.rst
+++ b/doc/source/algorithms.rst
@@ -46,6 +46,11 @@ the maximum pixel in the residue is greater than the threshold for this former r
 located at least 0.5 beams (and :math:`\sqrt{5}` pixels) away from all previous peaks, then this residual
 peak is identified as a new one.
 
+Errors on the Gaussian parameters
+---------------------------------
+Errors on each of the fitted parameters are computed using the
+formulae in Condon (1997) [#f2]_ and Condon et al. (1998) [#f3]_.
+
 .. _grouping:
 
 Grouping of Gaussians into sources
@@ -88,5 +93,11 @@ No color correction is performed when averaging channels. However, as is shown b
    The fractional error made in the spectral index while calculating with the incorrect frequency, with a second frequency which is 10 MHz different.
 
 
+.. rubric:: Footnotes
 
 .. [#f1] Katgert, P., Oort, M. J. A., & Windhorst, R. A. 1988, A&A, 195, 21
+
+.. [#f2] Condon, J. J. 1997, PASP, 109, 166
+
+.. [#f3] Condon, J. J., et al. 1998, ApJ, 115, 1693
+

--- a/doc/source/process_image.rst
+++ b/doc/source/process_image.rst
@@ -481,7 +481,11 @@ The advanced options are:
         This parameter is a Boolean (default is ``False``). If True, then during
         fitting the major and minor axes and PA of the Gaussians are fixed to
         the beam. Only the amplitude and position are fit. If False, all
-        parameters are fit.
+        parameters are fit. Note that when this option is activated, as a
+        consequence of using fewer free parameters, the estimated errors on the
+        peak and total flux densities are a factor of sqrt(2) lower compared to
+        the case in which all parameters are fit (see Condon 1997). Additionally,
+        the reported errors on the major and minor axes and the PA are zero.
 
     group_by_isl
         This parameter is a Boolean (default is ``False``). If True, all

--- a/doc/source/process_image.rst
+++ b/doc/source/process_image.rst
@@ -46,7 +46,7 @@ order:
    deconvolved size is computed assuming the theoretical beam, and the
    statistics in the source area and in the island are computed and
    stored. Errors on each of the fitted parameters are computed using the
-   formulae in Condon (1997) [#f1]_.
+   formulae in Condon (1997) [#f1]_ and Condon et al. (1998) [#f2]_.
 
 #. Groups nearby Gaussians within an island into sources. See :ref:`grouping`
    for details. Fluxes for the grouped Gaussians are summed to obtain the
@@ -56,7 +56,7 @@ order:
    output). The total source size is measured using moment analysis (see
    http://en.wikipedia.org/wiki/Image_moment for a nice overview of moment
    analysis). Errors on the source position and size are estimated using
-   Condon (1997), but additional uncertainties due to uncertainties in the
+   Condon (1997) and Condon et al. (1998), but additional uncertainties due to uncertainties in the
    constituent Gaussians may be estimated using a Monte Carlo technique.
 
 #. Continues with further processing, if the user has specified that one or more of the following modules be used:
@@ -462,7 +462,7 @@ The advanced options are:
     fdr_alpha
         This parameter is a float (default is 0.05) that sets the value of alpha
         for the FDR algorithm for thresholding. If ``thresh`` is ``'fdr'``, then
-        the estimate of ``fdr_alpha`` (see Hopkins et al. 2002 [#f2]_ for
+        the estimate of ``fdr_alpha`` (see Hopkins et al. 2002 [#f3]_ for
         details) is stored in this parameter.
 
     fdr_ratio
@@ -1142,14 +1142,14 @@ The options for this module are as follows:
 
 Polarization module
 -------------------
-If ``polarisation_do = True``, then the polarization properties of the sources are calculated. First, if ``pi_fit = True``, source detection is performed on the polarized intensity (PI) image [#f3]_ to detect sources without Stokes I counterparts. The polarization module then calculates the I, Q, U, and V flux densities, the total, linear, and circular polarisation fractions and the linear polarisation angle of each Gaussian and source. The linear polarisation angle is defined from North, with positive angles towards East. Flux densities are calculated by fitting the normalization of the Gaussians found using the Stokes I or PI images.
+If ``polarisation_do = True``, then the polarization properties of the sources are calculated. First, if ``pi_fit = True``, source detection is performed on the polarized intensity (PI) image [#f4]_ to detect sources without Stokes I counterparts. The polarization module then calculates the I, Q, U, and V flux densities, the total, linear, and circular polarisation fractions and the linear polarisation angle of each Gaussian and source. The linear polarisation angle is defined from North, with positive angles towards East. Flux densities are calculated by fitting the normalization of the Gaussians found using the Stokes I or PI images.
 
 For linearly polarised emission, the signal and noise add vectorially, giving a
 Rice distribution instead of a Gaussian one. To correct for this, a bias
 is estimated and removed from the polarisation fraction using the same method used for the
 NVSS catalog (see ftp://ftp.cv.nrao.edu/pub/nvss/catalog.ps). Errors on the linear and total
 polarisation fractions and polarisation angle are estimated using the debiased polarised flux density
-and standard error propagation. See Sparks & Axon (1999) [#f4]_ for a more detailed treatment.
+and standard error propagation. See Sparks & Axon (1999) [#f5]_ for a more detailed treatment.
 
 The options for this module are as follows:
 
@@ -1191,7 +1191,7 @@ The options for this module are as follows:
 
 Shapelet decomposition module
 -----------------------------
-If ``shapelet_do = True``, then islands are decomposed into shapelets. Shapelets are a set of 2-D basis functions (for details, see Refregier 2003 [#f5]_) that can be used to completely model any source, typically with far fewer parameters than pixels in the source. Shapelets are useful in particular for modeling complex islands that are not well modeled by Gaussians alone. PyBDSF can currently fit cartesian shapelets to an image. The shapelet parameters can be written to a catalog using ``write_catalog`` (see :ref:`write_catalog`).
+If ``shapelet_do = True``, then islands are decomposed into shapelets. Shapelets are a set of 2-D basis functions (for details, see Refregier 2003 [#f6]_) that can be used to completely model any source, typically with far fewer parameters than pixels in the source. Shapelets are useful in particular for modeling complex islands that are not well modeled by Gaussians alone. PyBDSF can currently fit cartesian shapelets to an image. The shapelet parameters can be written to a catalog using ``write_catalog`` (see :ref:`write_catalog`).
 
 For each island of emission, a shapelet decomposition is done after estimating the best values of the
 center, the scale :math:`\beta`, and nmax in the following way. First, an initial guess of :math:`\beta` is taken as :math:`2\sqrt{[m2(x)m2(y)]}`,
@@ -1248,10 +1248,12 @@ The options for this module are as follows:
 
 .. [#f1] Condon, J. J. 1997, PASP, 109, 166
 
-.. [#f2] Hopkins, A. M., Miller, C. J., Connolly, A. J., et al.  2002, AJ, 123, 1086
+.. [#f2] Condon, J. J., et al. 1998, ApJ, 115, 1693
 
-.. [#f3] The polarized intensity image is calculated as :math:`\sqrt{(Q^2 + U^2)}`.
+.. [#f3] Hopkins, A. M., Miller, C. J., Connolly, A. J., et al.  2002, AJ, 123, 1086
 
-.. [#f4] Sparks, W. B., & Axon, D. J. 1999, PASP, 111, 1298
+.. [#f4] The polarized intensity image is calculated as :math:`\sqrt{(Q^2 + U^2)}`.
 
-.. [#f5] Refregier, A. 2003, MNRAS, 338, 35.
+.. [#f5] Sparks, W. B., & Axon, D. J. 1999, PASP, 111, 1298
+
+.. [#f6] Refregier, A. 2003, MNRAS, 338, 35.


### PR DESCRIPTION
This PR fixes a number of issues with error estimation, including an incorrect treatment of the errors when correcting for projection effects and when the `fix_to_beam` option is enabled.