### PR TITLE
Fix saving of residual image and add option to save model image

### DIFF
--- a/bdsf/make_residimage.py
+++ b/bdsf/make_residimage.py
@@ -63,17 +63,20 @@ class Op_make_residimage(Op):
         img.model_gaus_arr = model_gaus
         img.resid_gaus_arr = resid_gaus
 
-        if img.opts.output_all:
+        if img.opts.output_all or img.opts.savefits_residim:
             if img.waveletimage:
                 resdir = img.basedir + '/wavelet/residual/'
-                moddir = img.basedir + '/wavelet/model/'
             else:
                 resdir = img.basedir + '/residual/'
-                moddir = img.basedir + '/model/'
             if not os.path.exists(resdir): os.makedirs(resdir)
-            if not os.path.exists(moddir): os.makedirs(moddir)
             func.write_image_to_file(img.use_io, img.imagename + '.resid_gaus.fits', resid_gaus, img, resdir)
             mylog.info('%s %s' % ('Writing', resdir+img.imagename+'.resid_gaus.fits'))
+        if img.opts.output_all or img.opts.savefits_modelim:
+            if img.waveletimage:
+                moddir = img.basedir + '/wavelet/model/'
+            else:
+                moddir = img.basedir + '/model/'
+            if not os.path.exists(moddir): os.makedirs(moddir)
             func.write_image_to_file(img.use_io, img.imagename + '.model.fits', (img.ch0_arr - resid_gaus), img, moddir)
             mylog.info('%s %s' % ('Writing', moddir+img.imagename+'.model_gaus.fits'))
 

--- a/bdsf/opts.py
+++ b/bdsf/opts.py
@@ -938,6 +938,9 @@ class Opts(object):
     savefits_meanim = Bool(False,
                              doc = "Save background mean image as fits file",
                              group = "output_opts")
+    savefits_modelim = Bool(False,
+                             doc = "Save Gaussian model image as fits file",
+                             group = "output_opts")
     savefits_det_rmsim = Bool(False,
                              doc = "Save detection background rms image as fits file",
                              group = "output_opts")

--- a/doc/source/process_image.rst
+++ b/doc/source/process_image.rst
@@ -761,6 +761,7 @@ The output options are:
       :term:`savefits_det_meanim`  False : Save detection background mean image as fits file
       :term:`savefits_det_rmsim` . False : Save detection background rms image as fits file
       :term:`savefits_meanim` .... False : Save background mean image as fits file
+      :term:`savefits_modelim` ... False : Save Gaussian model image as fits file
       :term:`savefits_normim` .... False : Save norm image as fits file
       :term:`savefits_rankim` .... False : Save island rank image as fits file
       :term:`savefits_residim` ... False : Save residual image as fits file
@@ -817,6 +818,9 @@ The output options are:
 
     savefits_meanim
         This parameter is a Boolean (default is ``False``). If ``True``\, save background mean image as a FITS file.
+
+    savefits_modelim
+        This parameter is a Boolean (default is ``False``). If ``True``\, save Gaussian model image as a FITS file.
 
     savefits_normim
         This parameter is a Boolean (default is ``False``). If ``True``\, save norm image as a FITS file.


### PR DESCRIPTION
This PR fixes issue #212 and adds a new option to `process_image` (called `savefits_modelim`) to save the Gaussian model image as well.