### PR TITLE
Replace distutils for Python 3.12

### DIFF
--- a/bdsf/functions.py
+++ b/bdsf/functions.py
@@ -1105,8 +1105,11 @@ def read_image_from_file(filename, img, indir, quiet=False):
     import os
     import numpy as N
     from copy import deepcopy as cp
-    from packaging.version import Version
     import warnings
+    try:
+        from packaging.version import Version
+    except ImportError:
+        from distutils.version import StrictVersion as Version
 
     mylog = mylogger.logging.getLogger("PyBDSM."+img.log+"Readfile")
     if indir is None or indir == './':
@@ -1517,7 +1520,10 @@ def write_image_to_file(use, filename, image, img, outdir=None,
 def make_fits_image(imagedata, wcsobj, beam, freq, equinox, telescope, xmin=0, ymin=0,
                     is_mask=False, shape=None):
     """Makes a simple FITS hdulist appropriate for single-channel images"""
-    from packaging.version import Version
+    try:
+        from packaging.version import Version
+    except ImportError:
+        from distutils.version import StrictVersion as Version
     try:
         from astropy.io import fits as pyfits
         use_header_update = False

--- a/bdsf/functions.py
+++ b/bdsf/functions.py
@@ -1105,7 +1105,7 @@ def read_image_from_file(filename, img, indir, quiet=False):
     import os
     import numpy as N
     from copy import deepcopy as cp
-    from distutils.version import StrictVersion
+    from packaging.version import Version
     import warnings
 
     mylog = mylogger.logging.getLogger("PyBDSM."+img.log+"Readfile")
@@ -1129,10 +1129,10 @@ def read_image_from_file(filename, img, indir, quiet=False):
                 use_sections = True
             except ImportError as err:
                 import pyfits
-                if StrictVersion(pyfits.__version__) < StrictVersion('2.2'):
+                if Version(pyfits.__version__) < Version('2.2'):
                     old_pyfits = True
                     use_sections = False
-                elif StrictVersion(pyfits.__version__) < StrictVersion('2.4'):
+                elif Version(pyfits.__version__) < Version('2.4'):
                     old_pyfits = False
                     use_sections = False
                 else:
@@ -1163,10 +1163,10 @@ def read_image_from_file(filename, img, indir, quiet=False):
                 use_sections = True
             except ImportError as err:
                 import pyfits
-                if StrictVersion(pyfits.__version__) < StrictVersion('2.2'):
+                if Version(pyfits.__version__) < Version('2.2'):
                     old_pyfits = True
                     use_sections = False
-                elif StrictVersion(pyfits.__version__) < StrictVersion('2.4'):
+                elif Version(pyfits.__version__) < Version('2.4'):
                     old_pyfits = False
                     use_sections = False
                 else:
@@ -1517,7 +1517,7 @@ def write_image_to_file(use, filename, image, img, outdir=None,
 def make_fits_image(imagedata, wcsobj, beam, freq, equinox, telescope, xmin=0, ymin=0,
                     is_mask=False, shape=None):
     """Makes a simple FITS hdulist appropriate for single-channel images"""
-    from distutils.version import StrictVersion
+    from packaging.version import Version
     try:
         from astropy.io import fits as pyfits
         use_header_update = False
@@ -1527,7 +1527,7 @@ def make_fits_image(imagedata, wcsobj, beam, freq, equinox, telescope, xmin=0, y
         # Due to changes in the way pyfits handles headers from version 3.1 on,
         # we need to check for older versions and change the setting of header
         # keywords accordingly.
-        if StrictVersion(pyfits.__version__) < StrictVersion('3.1'):
+        if Version(pyfits.__version__) < Version('3.1'):
             use_header_update = True
         else:
             use_header_update = False

--- a/bdsf/output.py
+++ b/bdsf/output.py
@@ -366,7 +366,10 @@ def write_fits_list(img, filename=None, sort_by='index', objtype='gaul',
     """ Write as FITS binary table.
     """
     from . import mylogger
-    from packaging.version import Version
+    try:
+        from packaging.version import Version
+    except ImportError:
+        from distutils.version import StrictVersion as Version
     try:
         from astropy.io import fits as pyfits
         use_header_update = False

--- a/bdsf/output.py
+++ b/bdsf/output.py
@@ -366,14 +366,14 @@ def write_fits_list(img, filename=None, sort_by='index', objtype='gaul',
     """ Write as FITS binary table.
     """
     from . import mylogger
-    from distutils.version import StrictVersion
+    from packaging.version import Version
     try:
         from astropy.io import fits as pyfits
         use_header_update = False
         use_from_columns = True
     except ImportError:
         import pyfits
-        if StrictVersion(pyfits.__version__) < StrictVersion('3.1'):
+        if Version(pyfits.__version__) < Version('3.1'):
             use_header_update = True
             use_from_columns = False
         else:

--- a/bdsf/psf_vary.py
+++ b/bdsf/psf_vary.py
@@ -43,7 +43,10 @@ class Op_psf_vary(Op):
             from astropy.io import fits as pyfits
             old_pyfits = False
         except ImportError as err:
-            from packaging.version import Version
+            try:
+                from packaging.version import Version
+            except ImportError:
+                from distutils.version import StrictVersion as Version
             import pyfits
             if Version(pyfits.__version__) < Version('2.2'):
                 old_pyfits = True

--- a/bdsf/psf_vary.py
+++ b/bdsf/psf_vary.py
@@ -43,9 +43,9 @@ class Op_psf_vary(Op):
             from astropy.io import fits as pyfits
             old_pyfits = False
         except ImportError as err:
-            from distutils.version import StrictVersion
+            from packaging.version import Version
             import pyfits
-            if StrictVersion(pyfits.__version__) < StrictVersion('2.2'):
+            if Version(pyfits.__version__) < Version('2.2'):
                 old_pyfits = True
             else:
                 old_pyfits = False

--- a/bdsf/pybdsf.py
+++ b/bdsf/pybdsf.py
@@ -697,7 +697,10 @@ def main():
     # greater is in common use.
     try:
         # IPython >= 0.11
-        from packaging.version import Version
+        try:
+            from packaging.version import Version
+        except ImportError:
+            from distutils.version import LooseVersion as Version
         from IPython import __version__ as ipython_version
         if Version(ipython_version) < Version('1.0.0'):
             from IPython.frontend.terminal.embed import InteractiveShellEmbed

--- a/bdsf/pybdsf.py
+++ b/bdsf/pybdsf.py
@@ -697,9 +697,9 @@ def main():
     # greater is in common use.
     try:
         # IPython >= 0.11
-        from distutils.version import LooseVersion
+        from packaging.version import Version
         from IPython import __version__ as ipython_version
-        if LooseVersion(ipython_version) < LooseVersion('1.0.0'):
+        if Version(ipython_version) < Version('1.0.0'):
             from IPython.frontend.terminal.embed import InteractiveShellEmbed
         else:
             from IPython.terminal.embed import InteractiveShellEmbed

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,10 @@ setup(
         'Topic :: Scientific/Engineering :: Astronomy'
     ],
     extras_require={
-        'ishell': ['ipython<8.11', 'matplotlib']
+        'ishell': [
+            'ipython!=8.11.*,!=8.12.*,!=8.13.*,!=8.14.*,!=8.15.*',
+            'matplotlib',
+        ],
     },
     install_requires=['backports.shutil_get_terminal_size',
                         'astropy', 'numpy', 'scipy'],

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
     },
     install_requires=['backports.shutil_get_terminal_size',
                         'astropy', 'numpy', 'scipy'],
+    python_requires=">=3.7",
     entry_points = {
         'console_scripts': [
             'pybdsf = bdsf.pybdsf:main [ishell]',


### PR DESCRIPTION
Python 3.12 no longer ships with `distutils`. Replaced the use of `distutils.version` with `packaging.version`.