### PR TITLE
Fix issue with frequency_sp being ignored

### DIFF
--- a/bdsf/collapse.py
+++ b/bdsf/collapse.py
@@ -60,6 +60,16 @@ class Op_collapse(Op):
             if pol == 'I':
               ch0 = img.image_arr[0, chan0]
               img.ch0_arr = ch0
+
+              # Construct weights so that desired channel has weight of 1 and all
+              # others have weight of 0.  The init_freq_collapse function will then
+              # select the intended frequency
+              c_list = img.opts.collapse_av
+              if c_list == []:
+                c_list = N.arange(img.image_arr.shape[1])
+              wtarr = N.zeros(len(c_list))
+              wtarr[chan0] = 1.0
+              init_freq_collapse(img, wtarr)
               mylogger.userinfo(mylog, 'Source extraction will be ' \
                                     'done on channel', '%i (%.3f MHz)' % \
                                     (chan0, img.frequency/1e6))

--- a/bdsf/collapse.py
+++ b/bdsf/collapse.py
@@ -32,7 +32,8 @@ class Op_collapse(Op):
         chan0 = img.opts.collapse_ch0
         c_list = img.opts.collapse_av
         c_wts = img.opts.collapse_wt
-        if c_list == []: c_list = N.arange(img.shape[1])
+        if not c_list:
+            c_list = N.arange(img.shape[1])
         if len(c_list) == 1 and c_mode=='average':
             c_mode = 'single'
             chan0 = c_list[0]
@@ -42,6 +43,12 @@ class Op_collapse(Op):
           ch0images = ['ch0_arr', 'ch0_Q_arr', 'ch0_U_arr', 'ch0_V_arr']
         else:
           ch0images = ['ch0_arr']
+
+        # Check whether the collapse channel index is sensible
+        if chan0 < 0 or chan0 >= len(c_list):
+            raise RuntimeError('The channel index (set with the "collapse_ch0" option) '
+                               'must be greater than zero and less than the number of '
+                               'channels ({}).'.format(len(c_list)))
 
         # assume all Stokes images have the same blank pixels as I:
         blank = N.isnan(img.image_arr[0])
@@ -64,9 +71,6 @@ class Op_collapse(Op):
               # Construct weights so that desired channel has weight of 1 and all
               # others have weight of 0.  The init_freq_collapse function will then
               # select the intended frequency
-              c_list = img.opts.collapse_av
-              if c_list == []:
-                c_list = N.arange(img.image_arr.shape[1])
               wtarr = N.zeros(len(c_list))
               wtarr[chan0] = 1.0
               init_freq_collapse(img, wtarr)

--- a/bdsf/psf_vary.py
+++ b/bdsf/psf_vary.py
@@ -57,6 +57,11 @@ class Op_psf_vary(Op):
             mylog.warning('PyFITS version is too old: psf_vary module skipped')
             return
 
+        if img.nisl == 0:
+            mylog.warning("No islands found. Skipping PSF variation estimation.")
+            img.completed_Ops.append('psf_vary')
+            return
+
         if opts.psf_fwhm is not None:
             # User has specified a constant PSF to use, so skip PSF fitting/etc.
             psf_maj = opts.psf_fwhm[0] # FWHM in deg

--- a/bdsf/shapefit.py
+++ b/bdsf/shapefit.py
@@ -29,6 +29,11 @@ class Op_shapelets(Op):
         bar = statusbar.StatusBar('Decomposing islands into shapelets ...... : ', 0, img.nisl)
         opts = img.opts
         if img.opts.shapelet_do:
+            if img.nisl == 0:
+                mylog.warning("No islands found. Skipping shapelet decomposition.")
+                img.completed_Ops.append('shapelets')
+                return
+
             if not opts.quiet:
                 bar.start()
 

--- a/doc/source/process_image.rst
+++ b/doc/source/process_image.rst
@@ -884,6 +884,10 @@ The options concerning multichannel images are:
         scale accordingly to calculate the beam per channel. If ``False``, then a
         constant value of the beam (that given in the header or specified with the ``beam`` parameter) is taken instead.
 
+        .. note::
+
+            This parameter is used only in the :ref:`spectralindex_do` module.
+
     beam_spectrum
         This parameter is a list of tuples (default is ``None``) that sets the FWHM of synthesized beam per channel. Specify as [(bmaj_ch1, bmin_ch1,
         bpa_ch1), (bmaj_ch2, bmin_ch2, bpa_ch2), etc.] in degrees. E.g.,
@@ -893,6 +897,11 @@ The options concerning multichannel images are:
         If ``None``, then the channel-dependent restoring beam is searched for in the header.
         If not found, the beam is either assumed to be a constant or to scale with frequency,
         depending on whether the parameter ``beam_sp_derive`` is ``False`` or ``True``.
+
+        .. note::
+
+            This parameter is used only in the :ref:`spectralindex_do` module. For normal fitting (outside of the spectral index module), a
+            constant value of the beam (that given in the header or specified with the ``beam`` parameter) is taken instead.
 
     collapse_av
         This parameter is a list of integers (default is ``[]``) that specifies the channels to be averaged to produce the


### PR DESCRIPTION
This PR fixes an issue described in #218, where the value of the `frequency_sp` option was ignored during the collapse of the image channels.