### PR TITLE
Set upper limit on NumPy version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ classifiers = [
 dependencies = [
     "backports.shutil_get_terminal_size",
     "astropy",
-    "numpy",
+    "numpy<2",
     "scipy",
 ]
 


### PR DESCRIPTION
Due to incompatibilities with NumPy 2.0, we need to restrict NumPy version to < 2.