### PR TITLE
Update Intel-based MacOS runner

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -1,13 +1,13 @@
 name: Build and upload to PyPI
 
 # Only build and upload when a new release tag is created
-# on:
-#   push:
-#     tags:
-#       - "v[0-9]+.[0-9]+.[0-9]+"
-#       - "v[0-9]+.[0-9]+.[0-9]+[a-z]+[0-9]+"
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9]+[a-z]+[0-9]+"
 # Alternatively, build on every branch push, tag push, and pull request change
-on: [push] #, pull_request]
+# on: [push, pull_request]
 
 jobs:
   build_wheels:
@@ -65,23 +65,23 @@ jobs:
           name: tarball
           path: dist/*.tar.gz
 
-  # upload_pypi:
-  #   name: Publish on PyPI
-  #   needs: [build_wheels, build_sdist]
-  #   runs-on: ubuntu-latest
-  #   permissions:
-  #     id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
-  #   # Upload to PyPI on every tag starting with 'v'
-  #   if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
-  #   # Alternatively, to publish when a GitHub Release is created, use the following rule:
-  #   # if: github.event_name == 'release' && github.event.action == 'published'
-  #   steps:
-  #     - uses: actions/download-artifact@v4
-  #       with:
-  #         path: dist  # put artifacts where next action expects them to be
-  #         merge-multiple: true
-  #     - uses: pypa/gh-action-pypi-publish@v1.10.1
-  #       with:
-  #         skip-existing: true
-  #         # To test:
-  #         # repository-url: https://test.pypi.org/legacy/
+  upload_pypi:
+    name: Publish on PyPI
+    needs: [build_wheels, build_sdist]
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
+    # Upload to PyPI on every tag starting with 'v'
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    # Alternatively, to publish when a GitHub Release is created, use the following rule:
+    # if: github.event_name == 'release' && github.event.action == 'published'
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist  # put artifacts where next action expects them to be
+          merge-multiple: true
+      - uses: pypa/gh-action-pypi-publish@v1.10.1
+        with:
+          skip-existing: true
+          # To test:
+          # repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -1,13 +1,13 @@
 name: Build and upload to PyPI
 
 # Only build and upload when a new release tag is created
-on:
-  push:
-    tags:
-      - "v[0-9]+.[0-9]+.[0-9]+"
-      - "v[0-9]+.[0-9]+.[0-9]+[a-z]+[0-9]+"
+# on:
+#   push:
+#     tags:
+#       - "v[0-9]+.[0-9]+.[0-9]+"
+#       - "v[0-9]+.[0-9]+.[0-9]+[a-z]+[0-9]+"
 # Alternatively, build on every branch push, tag push, and pull request change
-# on: [push, pull_request]
+on: [push] #, pull_request]
 
 jobs:
   build_wheels:
@@ -16,12 +16,12 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-latest, macos-12, macos-14]
+        os: [ubuntu-latest, macos-13, macos-14]
         toolchain:
           - {compiler: gcc, version: 12}
         include:
-          - os: macos-12
-            macosx_deployment_target: "12.0"
+          - os: macos-13
+            macosx_deployment_target: "13.0"
           - os: macos-14
             macosx_deployment_target: "14.0"
 
@@ -65,23 +65,23 @@ jobs:
           name: tarball
           path: dist/*.tar.gz
 
-  upload_pypi:
-    name: Publish on PyPI
-    needs: [build_wheels, build_sdist]
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
-    # Upload to PyPI on every tag starting with 'v'
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
-    # Alternatively, to publish when a GitHub Release is created, use the following rule:
-    # if: github.event_name == 'release' && github.event.action == 'published'
-    steps:
-      - uses: actions/download-artifact@v4
-        with:
-          path: dist  # put artifacts where next action expects them to be
-          merge-multiple: true
-      - uses: pypa/gh-action-pypi-publish@v1.10.1
-        with:
-          skip-existing: true
-          # To test:
-          # repository-url: https://test.pypi.org/legacy/
+  # upload_pypi:
+  #   name: Publish on PyPI
+  #   needs: [build_wheels, build_sdist]
+  #   runs-on: ubuntu-latest
+  #   permissions:
+  #     id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
+  #   # Upload to PyPI on every tag starting with 'v'
+  #   if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+  #   # Alternatively, to publish when a GitHub Release is created, use the following rule:
+  #   # if: github.event_name == 'release' && github.event.action == 'published'
+  #   steps:
+  #     - uses: actions/download-artifact@v4
+  #       with:
+  #         path: dist  # put artifacts where next action expects them to be
+  #         merge-multiple: true
+  #     - uses: pypa/gh-action-pypi-publish@v1.10.1
+  #       with:
+  #         skip-existing: true
+  #         # To test:
+  #         # repository-url: https://test.pypi.org/legacy/


### PR DESCRIPTION
GitHub no longer supports the Intel-based MacOS-12 runner. Updated to MacOS-13.