### PR TITLE
Fix multiprocessing deadlock

### DIFF
--- a/bdsf/multi_proc.py
+++ b/bdsf/multi_proc.py
@@ -108,6 +108,10 @@ def run_tasks(procs, err_q, out_q, num):
 
         for proc in procs:
             proc.join()
+            if proc.exitcode != 0:
+                raise RuntimeError(
+                    f"Process {proc.name} died unexpectedly (exit code: {proc.exitcode})"
+                )
 
     except Exception as e:
         # kill all slave processes on ctrl-C


### PR DESCRIPTION
### Bug description
A deadlock may occur in the function `run_tasks()` in `multi_proc.py`, if `out_q` is empty. This may happen, if one or more of the started processes die unexpectedly. 

### Solution
There are two ways to resolve this problem:

1. Do a non-blocking read on `out_q` and check if it's empty. If so, some results are apparently missing.
2. Check for a non-zero exit code of each joined process.

In both cases an exception should be raised. The second solution has the advantage that you can more easily access the exit code of the first process that died, and use it in the exception message. This MR therefore implements the second solution.

### How to test
To test that this solution works, make sure that one of the underlying processes die with a `SIGSEGV`. This can, for example, be accomplished by reverting [this change](https://github.com/lofar-astron/PyBDSF/pull/251/files#diff-9d9999ee843c1b1a32bb6ae26bd7c6b5d33eaf4bb122d13ac93e05fba0b08872R44) in `src/c++/MGFunction1.cc`.  Doing so, will raise a `SIGSEGV` at runtime, when the software is compiled and run with Numpy 2.x.

### Note
Building the software with Numpy 2.x is not trivial, because on most host systems, all packages are still compiled against Numpy 1.x. Follow the approach used in the CI pipeline https://github.com/lofar-astron/PyBDSF/blob/master/.github/workflows/ci.yml to build the software in a clean docker container.

It may be easier to just raise a signal in the aforementioned C++ file, instead of triggering the `SIGSEGV` through the incorrect call of a Numpy function (because that requires Numpy 2.x for building the software). The software can then be built on the host system. Just raising the signal should yield the same effect.