### PR TITLE
Accellerate calculation of standard deviations

### DIFF
--- a/bdsf/functions.py
+++ b/bdsf/functions.py
@@ -2176,7 +2176,7 @@ def bstat(indata, mask, kappa_npixbeam):
 
     mean  = numpy.mean(skpix)
     median = skpix[skpix.size//2]
-    sigma = numpy.std(skpix, ddof=1)
+    sigma =  (d2.sum()/(ct-1) - (m_raw-mean)**2 * ct/(ct-1) )**0.5
     mode = 2.5*median - 1.5*mean
     if sigma > 0.0:
         skew_par = abs(mean - median)/sigma


### PR DESCRIPTION
Surprisingly calculation of the standard deviation is an appreciable  fraction of our self-cal pipelines runtime somehow... I'll come back to a more complete solution in future probably, but for now this reuses the mean (which was already calculated) and also reuses a the computed deviations from the raw mean (calculated once only).  Unfortunately adds a bit of complexity, but makes quite a big impact for us (~20% in runtime)