### PR TITLE
Fix binary wheel build for Python 3.14

### DIFF
--- a/bdsf/multi_proc.py
+++ b/bdsf/multi_proc.py
@@ -24,16 +24,8 @@ try:
 except AttributeError:
     _ncpus = multiprocessing.cpu_count()
 
-if sys.platform == 'darwin' and sys.version_info >= (3, 8):
-    # We need to set spawn method to "fork" for macOS on Python 3.8+ where
-    # the default has been changed to "spawn", causing problems (see the
-    # discussion at https://github.com/ipython/ipython/issues/12396)
-    multiprocessing.set_start_method('fork')
-elif sys.platform == 'linux' and sys.version_info >= (3, 14):
-    # In Python 3.14, the default start method changed from "fork" to
-    # "forkserver" on Unix-like systems, but we need "fork".
-    multiprocessing.set_start_method('fork')
-
+# Set the start method to "fork". Other methods don't work with our codebase.
+multiprocessing.set_start_method('fork')
 
 __all__ = ('parallel_map',)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Scientific/Engineering :: Astronomy",
 ]
 dependencies = [
@@ -75,7 +76,7 @@ Documentation = "https://pybdsf.readthedocs.io"
 [tool.cibuildwheel]
 before-all = "cibuildwheel/before_all.sh"
 before-build = "cibuildwheel/before_build.sh"
-build = "cp3{9,10,11,12,13}-*"
+build = "cp3{9,10,11,12,13,14}-*"
 build-verbosity = 1
 environment = """ \
     BOOST_VERSION="1.87.0" \


### PR DESCRIPTION
In Python 3.14, the default method that `multiprocessing` uses to start a process on POSIX platforms changed from `fork` to `forkserver`. We cannot use `forkserver`, unless we restructure our code, so we need to explicitly set the start method to `fork` when running on Linux using Python 3.14 or later.

Fixes #265 