### PR TITLE
Make statusbar faster

### DIFF
--- a/bdsf/statusbar.py
+++ b/bdsf/statusbar.py
@@ -58,12 +58,15 @@ class StatusBar():
 
         sys.stdout.write('\x1b[1G')
 
-        # Check to prevent ZeroDivisionError if there are no items to process
+        # Handle the case where there are no items to process (prevents from
+        # dividing by zero later)
         if self.max == 0:
             sys.stdout.write(self.color + self.text + '[] 0/0\033[0m\n')
         else:
-            # Recalculate comp here (moved from increment) immediately after __getsize()
-            # to ensure the progress bar adapts correctly if the terminal was resized
+            # We are about to divide by self.max. We are inside the 'else' block,
+            # so self.max is not 0, meaning this division will not crash.
+            # We calculate this right after checking the terminal size (__getsize) 
+            # so the progress bar adapts to window resizing.
             self.comp = int(float(self.pos) / self.max * self.columns)
             sys.stdout.write(self.color + self.text + '[' + '=' * self.comp + self.busy_char + '-'*(self.columns - self.comp - 1) + '] ' + str(self.pos) + '/' + str(self.max) + '\033[0m')
             sys.stdout.write('\x1b[' + str(self.comp + 2 + 44) + 'G')

--- a/bdsf/statusbar.py
+++ b/bdsf/statusbar.py
@@ -60,7 +60,7 @@ class StatusBar():
 
         # Handle the case where there are no items to process (prevents from
         # dividing by zero later)
-        if self.max == 0:
+        if self.max <= 0:
             sys.stdout.write(self.color + self.text + '[] 0/0\033[0m\n')
         else:
             # We are about to divide by self.max, but it is safe in the 'else' block.

--- a/bdsf/statusbar.py
+++ b/bdsf/statusbar.py
@@ -63,9 +63,10 @@ class StatusBar():
         if self.max == 0:
             sys.stdout.write(self.color + self.text + '[] 0/0\033[0m\n')
         else:
-            # We are about to divide by self.max, but it is safe in the 'else' block.
-            # We calculate 'self.comp' right after checking the terminal size (__getsize) 
-            # so the progress bar adapts to possible window resizing.
+            # We are about to divide by self.max. We are inside the 'else' block,
+            # so self.max is not 0, meaning this division will not crash.
+            # We calculate this right after checking the terminal size (__getsize) 
+            # so the progress bar adapts to window resizing.
             self.comp = int(float(self.pos) / self.max * self.columns)
             sys.stdout.write(self.color + self.text + '[' + '=' * self.comp + self.busy_char + '-'*(self.columns - self.comp - 1) + '] ' + str(self.pos) + '/' + str(self.max) + '\033[0m')
             sys.stdout.write('\x1b[' + str(self.comp + 2 + 44) + 'G')

--- a/bdsf/statusbar.py
+++ b/bdsf/statusbar.py
@@ -51,21 +51,17 @@ class StatusBar():
                 self.columns = 1
         return
 
-    # Redraw progress bar
+    # redraw progress bar
     def __print(self):
         # Update terminal size with each actual frame rendering
         self.__getsize()
 
         sys.stdout.write('\x1b[1G')
-        
-        # Check to prevent ZeroDivisionError if there are no items to process
         if self.max == 0:
             sys.stdout.write(self.color + self.text + '[] 0/0\033[0m\n')
         else:
-            # Recalculate comp here (moved from increment) immediately after __getsize()
-            # to ensure the progress bar adapts correctly if the terminal was resized.
+            # Recalculate comp in case the terminal size (self.columns) has changed
             self.comp = int(float(self.pos) / self.max * self.columns)
-            
             sys.stdout.write(self.color + self.text + '[' + '=' * self.comp + self.busy_char + '-'*(self.columns - self.comp - 1) + '] ' + str(self.pos) + '/' + str(self.max) + '\033[0m')
             sys.stdout.write('\x1b[' + str(self.comp + 2 + 44) + 'G')
         sys.stdout.flush()

--- a/bdsf/statusbar.py
+++ b/bdsf/statusbar.py
@@ -51,16 +51,19 @@ class StatusBar():
                 self.columns = 1
         return
 
-    # redraw progress bar
+    # Redraw progress bar
     def __print(self):
-        # Update terminal size with each actual frame rendering
+        # Update terminal size with each frame rendering
         self.__getsize()
 
         sys.stdout.write('\x1b[1G')
+
+        # Check to prevent ZeroDivisionError if there are no items to process
         if self.max == 0:
             sys.stdout.write(self.color + self.text + '[] 0/0\033[0m\n')
         else:
-            # Recalculate comp in case the terminal size (self.columns) has changed
+            # Recalculate comp here (moved from increment) immediately after __getsize()
+            # to ensure the progress bar adapts correctly if the terminal was resized
             self.comp = int(float(self.pos) / self.max * self.columns)
             sys.stdout.write(self.color + self.text + '[' + '=' * self.comp + self.busy_char + '-'*(self.columns - self.comp - 1) + '] ' + str(self.pos) + '/' + str(self.max) + '\033[0m')
             sys.stdout.write('\x1b[' + str(self.comp + 2 + 44) + 'G')

--- a/bdsf/statusbar.py
+++ b/bdsf/statusbar.py
@@ -51,17 +51,21 @@ class StatusBar():
                 self.columns = 1
         return
 
-    # redraw progress bar
+    # Redraw progress bar
     def __print(self):
         # Update terminal size with each actual frame rendering
         self.__getsize()
 
         sys.stdout.write('\x1b[1G')
+        
+        # Check to prevent ZeroDivisionError if there are no items to process
         if self.max == 0:
             sys.stdout.write(self.color + self.text + '[] 0/0\033[0m\n')
         else:
-            # Recalculate comp in case the terminal size (self.columns) has changed
+            # Recalculate comp here (moved from increment) immediately after __getsize()
+            # to ensure the progress bar adapts correctly if the terminal was resized.
             self.comp = int(float(self.pos) / self.max * self.columns)
+            
             sys.stdout.write(self.color + self.text + '[' + '=' * self.comp + self.busy_char + '-'*(self.columns - self.comp - 1) + '] ' + str(self.pos) + '/' + str(self.max) + '\033[0m')
             sys.stdout.write('\x1b[' + str(self.comp + 2 + 44) + 'G')
         sys.stdout.flush()

--- a/bdsf/statusbar.py
+++ b/bdsf/statusbar.py
@@ -63,10 +63,9 @@ class StatusBar():
         if self.max == 0:
             sys.stdout.write(self.color + self.text + '[] 0/0\033[0m\n')
         else:
-            # We are about to divide by self.max. We are inside the 'else' block,
-            # so self.max is not 0, meaning this division will not crash.
-            # We calculate this right after checking the terminal size (__getsize) 
-            # so the progress bar adapts to window resizing.
+            # We are about to divide by self.max, but it is safe in the 'else' block.
+            # We calculate 'self.comp' right after checking the terminal size (__getsize) 
+            # so the progress bar adapts to possible window resizing.
             self.comp = int(float(self.pos) / self.max * self.columns)
             sys.stdout.write(self.color + self.text + '[' + '=' * self.comp + self.busy_char + '-'*(self.columns - self.comp - 1) + '] ' + str(self.pos) + '/' + str(self.max) + '\033[0m')
             sys.stdout.write('\x1b[' + str(self.comp + 2 + 44) + 'G')

--- a/bdsf/statusbar.py
+++ b/bdsf/statusbar.py
@@ -1,7 +1,7 @@
+
 """Display an animated statusbar"""
-from __future__ import absolute_import
 import sys
-import os
+import time
 from . import functions as func
 
 class StatusBar():
@@ -23,6 +23,11 @@ class StatusBar():
         self.inc =  0
         self.started = 0
         self.color = color
+        
+        # 5 frames per second
+        self.min_interval = 0.2
+        self.last_print_time = 0.0
+        
         self.__getsize()
         if max > 0:
             self.comp = int(float(self.pos) / self.max * self.columns)
@@ -35,21 +40,28 @@ class StatusBar():
             rows, columns = func.getTerminalSize()
         except ValueError:
             rows = columns = 0
+            
         if int(columns) > self.max + 2 + 44 + (len(str(self.max))*2 + 2):
             self.columns = self.max
         else:
             # note: -2 is for brackets, -44 for 'Fitting islands...' text, rest is for pos/max text
             self.columns = int(columns) - 2 - 44 - (len(str(self.max))*2 + 2)
+            # Protection against negative or zero column width
+            if self.columns < 1:
+                self.columns = 1
         return
 
     # redraw progress bar
     def __print(self):
+        # Update terminal size with each actual frame rendering
         self.__getsize()
 
         sys.stdout.write('\x1b[1G')
         if self.max == 0:
             sys.stdout.write(self.color + self.text + '[] 0/0\033[0m\n')
         else:
+            # Recalculate comp in case the terminal size (self.columns) has changed
+            self.comp = int(float(self.pos) / self.max * self.columns)
             sys.stdout.write(self.color + self.text + '[' + '=' * self.comp + self.busy_char + '-'*(self.columns - self.comp - 1) + '] ' + str(self.pos) + '/' + str(self.max) + '\033[0m')
             sys.stdout.write('\x1b[' + str(self.comp + 2 + 44) + 'G')
         sys.stdout.flush()
@@ -61,14 +73,13 @@ class StatusBar():
         self.spin_pos += 1
         if self.spin_pos >= len(busy_chars):
             self.spin_pos = 0
-        # display the busy spinning icon
         self.busy_char = busy_chars[self.spin_pos]
-        sys.stdout.write(self.color + busy_chars[self.spin_pos] + '\x1b[1D' + '\033[0m')
-        sys.stdout.flush()
 
     # increment number of completed items
     def increment(self):
         self.inc = 1
+        current_time = time.time()
+        
         if (self.pos + self.inc) >= self.max:
             self.pos = self.max
             self.comp = self.columns
@@ -78,14 +89,18 @@ class StatusBar():
         else:
             self.pos += self.inc
             self.inc = 0
-            self.spin()
-            self.comp = int(float(self.pos) / self.max \
-                * self.columns)
-            self.__print()
+            
+            # Only refresh if at least 0.2 seconds have passed since the last print
+            if current_time - self.last_print_time >= self.min_interval:
+                self.spin()
+                self.__print()
+                self.last_print_time = current_time
+                
         return 1
 
     def start(self):
         self.started = 1
+        self.last_print_time = time.time()
         self.__print()
 
     def stop(self):


### PR DESCRIPTION
This does not require an extensive testing, since I havent touched computations. Just look at `ncalls` and it explains everything. Now printing and checking the terminal size occurs only 5x / sec.
For a 1.5 GB FITS:
before:
```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
     5823    0.018    0.000   10.835    0.002 /home/akurek/miniconda3/envs/pybdsf_3_14/lib/python3.14/site-packages/bdsf/statusbar.py:70(increment)
     5841    0.036    0.000   10.809    0.002 /home/akurek/miniconda3/envs/pybdsf_3_14/lib/python3.14/site-packages/bdsf/statusbar.py:46(__print)
     5851    0.023    0.000   10.764    0.002 /home/akurek/miniconda3/envs/pybdsf_3_14/lib/python3.14/site-packages/bdsf/statusbar.py:33(__getsize)
```
after:
```
     5823    0.007    0.000    0.208    0.000 /home/akurek/miniconda3/envs/pybdsf_3_14/lib/python3.14/site-packages/bdsf/statusbar.py:79(increment)
       87    0.001    0.000    0.260    0.003 /home/akurek/miniconda3/envs/pybdsf_3_14/lib/python3.14/site-packages/bdsf/statusbar.py:56(__print)
       97    0.001    0.000    0.294    0.003 /home/akurek/miniconda3/envs/pybdsf_3_14/lib/python3.14/site-packages/bdsf/statusbar.py:40(__getsize)
```
This 3 functions are 52x faster.
The entire run is 2.6% faster.