### PR TITLE
Cleanup of `rmsimage.py`

### DIFF
--- a/bdsf/rmsimage.py
+++ b/bdsf/rmsimage.py
@@ -162,7 +162,6 @@ class Op_rmsimage(Op):
         # the bright source is embedded inside a large island or not. If it is,
         # exclude it from the bright-island list. Also find the size of the
         # largest island at this threshold to set the large-scale rms_box
-        bright_threshold = threshold
         threshold = 10.0
         if img.masked:
             act_pixels = ~(mask.copy())

--- a/bdsf/rmsimage.py
+++ b/bdsf/rmsimage.py
@@ -142,7 +142,6 @@ class Op_rmsimage(Op):
         shape = image.shape
         isl_size_bright = []
         isl_area_highthresh = []
-        isl_peak = []
         threshold = start_thresh
         if do_adapt:
             mylogger.userinfo(mylog, "Using adaptive scaling of rms_box")
@@ -165,7 +164,6 @@ class Op_rmsimage(Op):
                     isl_area_highthresh.append(size_area)
                     isl_maxposn.append(tuple(np.array(np.unravel_index(np.argmax(image[s]), image[s].shape))+\
                           np.array((s[0].start, s[1].start))))
-                    isl_peak.append(ndimage.maximum(image[s], labels[s], idx+1))
 
         # Check islands found above at thresh_isl threshold to determine if
         # the bright source is embedded inside a large island or not. If it is,

--- a/bdsf/rmsimage.py
+++ b/bdsf/rmsimage.py
@@ -21,7 +21,6 @@ from . import mylogger
 from . import functions as func
 from .functions import read_image_from_file
 from . import multi_proc as mp
-from . import _cbdsm
 
 
 def mapcoord_threaded(a, axs, *args, ncores=8, **kwargs):
@@ -198,10 +197,8 @@ class Op_rmsimage(Op):
         mylog.info('Maximum extent of largest 10-sigma island using clipped rms (pixels) = '+str(max_isl_size))
         if len(isl_size_highthresh) == 0:
             max_isl_size_highthresh = 0.0
-            max_isl_size_lowthresh = 0.0
         else:
             max_isl_size_highthresh = max(isl_size_highthresh)
-            max_isl_size_lowthresh = max(isl_size_lowthresh)
 
         if hasattr(img, '_adapt_rms_isl_pos'):
             isl_pos = img._adapt_rms_isl_pos # set isl_pos to existing value (for wavelet analysis)

--- a/bdsf/rmsimage.py
+++ b/bdsf/rmsimage.py
@@ -175,7 +175,6 @@ class Op_rmsimage(Op):
         slices = ndimage.find_objects(labels)
         isl_size = []
         isl_size_highthresh = []
-        isl_size_lowthresh = []
         isl_snr = []
         for idx, s in enumerate(slices):
             isl_area_lowthresh = (labels[s] == idx+1).sum()/img.pixel_beamarea()*2.0
@@ -186,7 +185,6 @@ class Op_rmsimage(Op):
                 bright_indx = isl_maxposn.index(isl_maxposn_lowthresh)
                 if isl_area_lowthresh < 25.0 or isl_area_lowthresh/isl_area_highthresh[bright_indx] < 8.0:
                     isl_pos.append(isl_maxposn_lowthresh)
-                    isl_size_lowthresh.append(max([s[0].stop-s[0].start, s[1].stop-s[1].start]))
                     isl_size_highthresh.append(isl_size_bright[bright_indx])
                     isl_snr.append(isl_peak[bright_indx]/crms)
 

--- a/bdsf/rmsimage.py
+++ b/bdsf/rmsimage.py
@@ -15,7 +15,7 @@ from concurrent.futures import ThreadPoolExecutor
 import numpy as np
 from scipy import interpolate, ndimage
 
-from .image import Op, Image, NArray, List
+from .image import Op
 from . import const
 from . import mylogger
 from . import functions as func

--- a/bdsf/rmsimage.py
+++ b/bdsf/rmsimage.py
@@ -178,7 +178,6 @@ class Op_rmsimage(Op):
         isl_size_highthresh = []
         isl_size_lowthresh = []
         isl_snr = []
-        thratio = threshold/bright_threshold
         for idx, s in enumerate(slices):
             isl_area_lowthresh = (labels[s] == idx+1).sum()/img.pixel_beamarea()*2.0
             isl_maxposn_lowthresh = tuple(np.array(np.unravel_index(np.argmax(image[s]), image[s].shape))+
@@ -203,7 +202,6 @@ class Op_rmsimage(Op):
         else:
             max_isl_size_highthresh = max(isl_size_highthresh)
             max_isl_size_lowthresh = max(isl_size_lowthresh)
-            avg_max_isl_size = (max_isl_size_highthresh + max_isl_size_lowthresh) / 2.0
 
         if hasattr(img, '_adapt_rms_isl_pos'):
             isl_pos = img._adapt_rms_isl_pos # set isl_pos to existing value (for wavelet analysis)
@@ -428,10 +426,8 @@ class Op_rmsimage(Op):
         if img.masked:
             unmasked = np.where(~img.mask_arr)
             stdsub = np.std(rms[unmasked])
-            maxrms = np.max(rms[unmasked])
         else:
             stdsub = np.std(rms)
-            maxrms = np.max(rms)
 
         rms_expect = img.clipped_rms/sqrt(2)/img.rms_box[0]*fw_pix
         mylog.debug('%s %10.6f %s' % ('Standard deviation of rms image = ', stdsub*1000.0, 'mJy'))
@@ -458,10 +454,8 @@ class Op_rmsimage(Op):
         if img.masked:
             unmasked = np.where(~img.mask_arr)
             stdsub = np.std(mean[unmasked])
-            maxmean = np.max(mean[unmasked])
         else:
             stdsub = np.std(mean)
-            maxmean = np.max(mean)
         rms_expect = img.clipped_rms/img.rms_box[0]*fw_pix
         mylog.debug('%s %10.6f %s' % ('Standard deviation of mean image = ', stdsub*1000.0, 'mJy'))
         mylog.debug('%s %10.6f %s' % ('Expected standard deviation = ', rms_expect*1000.0, 'mJy'))

--- a/bdsf/rmsimage.py
+++ b/bdsf/rmsimage.py
@@ -174,7 +174,6 @@ class Op_rmsimage(Op):
         slices = ndimage.find_objects(labels)
         isl_size = []
         isl_size_highthresh = []
-        isl_snr = []
         for idx, s in enumerate(slices):
             isl_area_lowthresh = (labels[s] == idx+1).sum()/img.pixel_beamarea()*2.0
             isl_maxposn_lowthresh = tuple(np.array(np.unravel_index(np.argmax(image[s]), image[s].shape))+
@@ -185,7 +184,6 @@ class Op_rmsimage(Op):
                 if isl_area_lowthresh < 25.0 or isl_area_lowthresh/isl_area_highthresh[bright_indx] < 8.0:
                     isl_pos.append(isl_maxposn_lowthresh)
                     isl_size_highthresh.append(isl_size_bright[bright_indx])
-                    isl_snr.append(isl_peak[bright_indx]/crms)
 
         if len(isl_size) == 0:
             max_isl_size = 0.0

--- a/bdsf/rmsimage.py
+++ b/bdsf/rmsimage.py
@@ -135,7 +135,6 @@ class Op_rmsimage(Op):
         isl_size_bright = []
         isl_area_highthresh = []
         isl_peak = []
-        max_isl_brightsize = 0.0
         threshold = start_thresh
         if do_adapt:
             mylogger.userinfo(mylog, "Using adaptive scaling of rms_box")
@@ -488,7 +487,6 @@ class Op_rmsimage(Op):
         """Calls map_2d and checks for problems"""
         mylog = mylogger.logging.getLogger("PyBDSF."+img.log+"Rmsimage.Calcmaps ")
         rms_ok = False
-        mylog = mylogger.logging.getLogger("PyBDSF."+img.log+"Rmsimage.Calcmaps ")
         opts = img.opts
         kappa = map_opts[0]
         spline_rank = opts.spline_rank

--- a/bdsf/rmsimage.py
+++ b/bdsf/rmsimage.py
@@ -582,7 +582,6 @@ class Op_rmsimage(Op):
         mask_small = mask
         axes, mean_map1, rms_map1 = self.rms_mean_map(arr, mask_small, kappa, box, ncores)
         ax = [self.remap_axis(ashp, axv) for (ashp, axv) in zip(arr.shape, axes)][-1::-1]
-        pt_src_scale = box[0]
         if do_adapt:
             out_rms2 = np.zeros(rms_map1.shape, dtype=np.float32)
             out_mean2 = np.zeros(rms_map1.shape, dtype=np.float32)

--- a/bdsf/rmsimage.py
+++ b/bdsf/rmsimage.py
@@ -571,8 +571,7 @@ class Op_rmsimage(Op):
                 calculated map
         do_adapt: use adaptive binning
         """
-        mask_small = mask
-        axes, mean_map1, rms_map1 = self.rms_mean_map(arr, mask_small, kappa, box, ncores)
+        axes, mean_map1, rms_map1 = self.rms_mean_map(arr, mask, kappa, box, ncores)
         ax = [self.remap_axis(ashp, axv) for (ashp, axv) in zip(arr.shape, axes)][-1::-1]
         if do_adapt:
             out_rms2 = np.zeros(rms_map1.shape, dtype=np.float32)

--- a/bdsf/rmsimage.py
+++ b/bdsf/rmsimage.py
@@ -8,7 +8,7 @@ where for 3D case it will calculate maps for each plane (=
 Stokes images).
 """
 import os
-from math import sqrt, log
+from math import sqrt, log, floor, ceil
 import itertools
 from concurrent.futures import ThreadPoolExecutor
 
@@ -1020,7 +1020,6 @@ class Op_rmsimage(Op):
         compressed image (e.g. it has no exact counterpart, and it's value
         should be obtained by interpolation)
         """
-        from math import floor, ceil
         res = np.zeros(size, dtype=np.float32)
 
         for i in range(len(arr) - 1):


### PR DESCRIPTION
- `max_isl_brightsize` is never used.
- `mylog = mylogger.logging.getLogger("PyBDSF."+img.log+"Rmsimage.Calcmaps ")` was a duplicate - the same line is 2 lines above.
- `thratio`, `avg_max_isl_size`, `maxrms`, `maxmean`, `pt_src_scale` are computed but not used.