### PR TITLE
Remove `getTerminalSize`

### DIFF
--- a/bdsf/functions.py
+++ b/bdsf/functions.py
@@ -1968,19 +1968,6 @@ def make_src_mask(mask_size, posn_pix, aperture_pix):
     mask[tuple(submask_slice)] = submask
     return mask
 
-def getTerminalSize():
-    """Returns the terminal size as a tuple (lines, columns).
-    
-    Uses the built-in shutil module, ensuring cross-platform
-    compatibility
-    """
-    # shutil.get_terminal_size accepts a fallback in the format (columns, lines)
-    # We use (0, 0) as the fallback to match the original function's behavior
-    size = get_terminal_size(fallback=(0, 0))
-    
-    # Return the result as (lines, columns)
-    return size.lines, size.columns
-
 def eval_func_tuple(f_args):
     """Takes a tuple of a function and args, evaluates and returns result
 

--- a/bdsf/interface.py
+++ b/bdsf/interface.py
@@ -535,9 +535,11 @@ def print_opts(grouped_opts_list, img, banner=None):
     """
     from .image import Image
     import os
-    from . import functions as func
+    import shutil
 
-    termy, termx = func.getTerminalSize() # note: returns row, col -> y, x
+    tsize = shutil.get_terminal_size()
+    termx = tsize.columns
+    termy = tsize.lines
     minwidth = 28 # minimum width for parameter names and values
 
     # Define colors for output

--- a/bdsf/interface.py
+++ b/bdsf/interface.py
@@ -537,9 +537,8 @@ def print_opts(grouped_opts_list, img, banner=None):
     import os
     import shutil
 
-    tsize = shutil.get_terminal_size()
+    tsize = shutil.get_terminal_size(fallback=(0, 0))
     termx = tsize.columns
-    termy = tsize.lines
     minwidth = 28 # minimum width for parameter names and values
 
     # Define colors for output

--- a/bdsf/statusbar.py
+++ b/bdsf/statusbar.py
@@ -2,7 +2,7 @@
 """Display an animated statusbar"""
 import sys
 import time
-from . import functions as func
+import shutil
 
 class StatusBar():
     # class variables:
@@ -36,10 +36,10 @@ class StatusBar():
 
     # find number of columns in terminal
     def __getsize(self):
-        try:
-            rows, columns = func.getTerminalSize()
-        except ValueError:
-            rows = columns = 0
+        import shutil
+        tsize = shutil.get_terminal_size(fallback=(0, 0))
+        columns = tsize.columns
+        rows = tsize.lines
             
         if int(columns) > self.max + 2 + 44 + (len(str(self.max))*2 + 2):
             self.columns = self.max

--- a/bdsf/statusbar.py
+++ b/bdsf/statusbar.py
@@ -36,10 +36,8 @@ class StatusBar():
 
     # find number of columns in terminal
     def __getsize(self):
-        import shutil
         tsize = shutil.get_terminal_size(fallback=(0, 0))
         columns = tsize.columns
-        rows = tsize.lines
             
         if int(columns) > self.max + 2 + 44 + (len(str(self.max))*2 + 2):
             self.columns = self.max


### PR DESCRIPTION
Currently this function makes no sense, it only refers to `shutil.get_terminal_size`. Better to call `get_terminal_size` directly. its working fine.