### PR TITLE
Drop MacOS-13 and add MacOS-15 for GitHub workflow

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -16,14 +16,14 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-latest, macos-13, macos-14]
+        os: [ubuntu-latest, macos-14, macos-15]
         toolchain:
-          - {compiler: gcc, version: 12}
+          - {compiler: gcc, version: 15}
         include:
-          - os: macos-13
-            macosx_deployment_target: "13.0"
           - os: macos-14
             macosx_deployment_target: "14.0"
+          - os: macos-15
+            macosx_deployment_target: "15.0"
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Switched to MacOS-15, because GitHub runners no longer support Mac-OS13. Also updated GCC compiler from version 12 to 15.