### PR TITLE
Use fork-style multiprocessing context

### DIFF
--- a/bdsf/multi_proc.py
+++ b/bdsf/multi_proc.py
@@ -25,8 +25,11 @@ try:
 except AttributeError:
     _ncpus = multiprocessing.cpu_count()
 
-# Set the start method to "fork". Other methods don't work with our codebase.
-multiprocessing.set_start_method('fork')
+# PyBDSF currently relies on fork-style multiprocessing.
+# The spawn and forkserver start methods are not supported because
+# parts of the codebase assume inherited interpreter state and are
+# not safe for re-import during process startup.
+fork_context = multiprocessing.get_context("fork")
 
 __all__ = ('parallel_map',)
 
@@ -181,7 +184,7 @@ def parallel_map(function, sequence, numcores=None, bar=None, weights=None):
     if numcores < 1:
         numcores = 1
 
-    manager = multiprocessing.Manager()
+    manager = fork_context.Manager()
 
     out_q = manager.Queue()
     err_q = manager.Queue()
@@ -220,7 +223,7 @@ def parallel_map(function, sequence, numcores=None, bar=None, weights=None):
     while len(sequence[-1]) == 0:
         sequence.pop()
 
-    procs = [multiprocessing.Process(target=worker,
+    procs = [fork_context.Process(target=worker,
              args=(function, ii, chunk, out_q, err_q, lock, bar, bar_state,
                    preserve_order))
              for ii, chunk in enumerate(sequence)]


### PR DESCRIPTION
PyBDSF currently relies on fork-style multiprocessing. The spawn and forkserver start methods are not supported because parts of the codebase assume inherited interpreter state and are not safe for re-import during process startup.