### PR TITLE
Make printing of stats of residual images optional

### DIFF
--- a/bdsf/make_residimage.py
+++ b/bdsf/make_residimage.py
@@ -155,17 +155,18 @@ class Op_make_residimage(Op):
                 resid = resid_shap[tuple(isl.bbox)]
                 self.calc_resid_mean_rms(isl, resid, type='shap')
 
-            # Calculate some statistics for the Shapelet residual image
-            non_masked = N.where(~N.isnan(img.ch0_arr))
-            mean = N.mean(resid_shap[non_masked], axis=None)
-            std_dev = N.std(resid_shap[non_masked], axis=None)
-            skew = stats.skew(resid_shap[non_masked], axis=None)
-            kurt = stats.kurtosis(resid_shap[non_masked], axis=None)
-            mylog.info("Statistics of the Shapelet residual image:")
-            mylog.info("        mean: %.3e (Jy/beam)" % mean)
-            mylog.info("    std. dev: %.3e (Jy/beam)" % std_dev)
-            mylog.info("        skew: %.3f" % skew)
-            mylog.info("    kurtosis: %.3f" % kurt)
+            if img.opts.residual_stats_do:
+                # Calculate some statistics for the Shapelet residual image
+                non_masked = N.where(~N.isnan(img.ch0_arr))
+                mean = N.mean(resid_shap[non_masked], axis=None)
+                std_dev = N.std(resid_shap[non_masked], axis=None)
+                skew = stats.skew(resid_shap[non_masked], axis=None)
+                kurt = stats.kurtosis(resid_shap[non_masked], axis=None)
+                mylog.info("Statistics of the Shapelet residual image:")
+                mylog.info("        mean: %.3e (Jy/beam)" % mean)
+                mylog.info("    std. dev: %.3e (Jy/beam)" % std_dev)
+                mylog.info("        skew: %.3f" % skew)
+                mylog.info("    kurtosis: %.3f" % kurt)
 
         img.completed_Ops.append('make_residimage')
         return img

--- a/bdsf/make_residimage.py
+++ b/bdsf/make_residimage.py
@@ -85,18 +85,19 @@ class Op_make_residimage(Op):
             resid = resid_gaus[tuple(isl.bbox)]
             self.calc_resid_mean_rms(isl, resid, type='gaus')
 
-        # Calculate some statistics for the Gaussian residual image
-        resid_gaus_non_masked = resid_gaus[N.where(~N.isnan(img.ch0_arr))]
-        mean = N.mean(resid_gaus_non_masked, axis=None)
-        std_dev = N.std(resid_gaus_non_masked, axis=None)
-        skew = stats.skew(resid_gaus_non_masked, axis=None)
-        kurt = stats.kurtosis(resid_gaus_non_masked, axis=None)
-        stat_msg = "Statistics of the Gaussian residual image:\n"
-        stat_msg += "        mean: %.3e (Jy/beam)\n" % mean
-        stat_msg += "    std. dev: %.3e (Jy/beam)\n" % std_dev
-        stat_msg += "        skew: %.3f\n" % skew
-        stat_msg += "    kurtosis: %.3f" % kurt
-        mylog.info(stat_msg)
+        if img.opts.residual_stats_do:
+            # Calculate some statistics for the Gaussian residual image
+            resid_gaus_non_masked = resid_gaus[N.where(~N.isnan(img.ch0_arr))]
+            mean = N.mean(resid_gaus_non_masked, axis=None)
+            std_dev = N.std(resid_gaus_non_masked, axis=None)
+            skew = stats.skew(resid_gaus_non_masked, axis=None)
+            kurt = stats.kurtosis(resid_gaus_non_masked, axis=None)
+            stat_msg = "Statistics of the Gaussian residual image:\n"
+            stat_msg += "        mean: %.3e (Jy/beam)\n" % mean
+            stat_msg += "    std. dev: %.3e (Jy/beam)\n" % std_dev
+            stat_msg += "        skew: %.3f\n" % skew
+            stat_msg += "    kurtosis: %.3f" % kurt
+            mylog.info(stat_msg)
 
         # Now residual image for shapelets
         if img.opts.shapelet_do:

--- a/bdsf/opts.py
+++ b/bdsf/opts.py
@@ -710,6 +710,11 @@ class Opts(object):
                                  "faster but also uses much more memory.",
                              group = "atrous_do")
 
+    residual_stats_do = Bool(False,
+                             doc = "Calculate and print to log statistics of residual "\
+                             "images (there is a computational cost)",
+                             group = "atrous_do")
+
     #--------------------------------FLAGGING OPTIONS--------------------------------
     flag_smallsrc = Bool(False,
                              doc = "Flag sources smaller than "\

--- a/bdsf/opts.py
+++ b/bdsf/opts.py
@@ -710,11 +710,6 @@ class Opts(object):
                                  "faster but also uses much more memory.",
                              group = "atrous_do")
 
-    residual_stats_do = Bool(False,
-                             doc = "Calculate and print to log statistics of residual "\
-                             "images (there is a computational cost)",
-                             group = "atrous_do")
-
     #--------------------------------FLAGGING OPTIONS--------------------------------
     flag_smallsrc = Bool(False,
                              doc = "Flag sources smaller than "\
@@ -968,6 +963,11 @@ class Opts(object):
     quiet = Bool(False,
                              doc = "Suppress text output to screen. Output is "\
                                  "still sent to the log file as usual",
+                             group = "output_opts")
+
+    residual_stats_do = Bool(False,
+                             doc = "Calculate and print to log statistics of residual "\
+                             "images (there is a computational cost)",
                              group = "output_opts")
 
 


### PR DESCRIPTION
Calculating them has a significant computational load for my SKA reference run