### PR TITLE
Fix Gaussian fitting

### DIFF
--- a/bdsf/gausfit.py
+++ b/bdsf/gausfit.py
@@ -456,13 +456,13 @@ class Op_gausfit(Op):
                     s_peak = ((1.0-t) * (1.0-u) * fit_image[x1, y1] + t * (1.0-u) * fit_image[x1+1, y1] +
                               t * u * fit_image[x1+1, y1+1] + (1.0-t) * u * fit_image[x1, y1+1])
                     mompara[0] = s_peak
-                    par = [mompara.tolist()]
+                    par = mompara.tolist()
                     par[3] /= fwsig
                     par[4] /= fwsig
-                    gaul, fgaul = self.flag_gaussians(par, opts,
+                    gaul, fgaul = self.flag_gaussians([par], opts,
                                                       beam, thr0, peak, shape, isl.mask_active,
                                                       isl.image, size)
-            except:
+            except ValueError:
                 pass
 
         # Return whatever we got


### PR DESCRIPTION
If you change the except ... pass to:
```
except
    import traceback
    traceback.print_exc()
```

You will see a lot of:

>     mompara[4] = sqrt((m2[0]+m2[1]-sqrt((m2[0]-m2[1])*(m2[0]-m2[1])+4.0*m11*m11))/(2.0*tot))*fwsig
>                  ~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> ValueError: expected a nonnegative input, got -269496.22772412334
> Fitting islands with Gaussians .......... : [[DEBUG] par before scaling = [[0.0008932634111046536, 26.642511490119873, 42.94617048094525, 28.269918304262394, 14.512309202635803, 93.43133802007331]]---------------------------] 11/17595
> [ERROR] Exception in moment analysis for island 8917
> Traceback (most recent call last):
>   File "/home/akurek/miniconda3/envs/pybdsf_3_14/lib/python3.14/site-packages/bdsf/gausfit.py", line 461, in fit_island
>     par[3] /= fwsig
>     ~~~^^^
> IndexError: list index out of range

In the original code
`par = [mompara.tolist()]`
created a list of lists. But then
`par[3] /= fwsig`
indexed the outer list producing IndexError, which was silently caught. In other words, this block always generated an exception.

Changed to:
`par = mompara.tolist()`
`par` became a list of 6 numbers.

In result, flag_gaussians(par, …) expected a list of Gaussians but received a flat list. Iterating over it yielded floats, causing TypeError: cannot unpack non-iterable float object. So keep `par_list = mompara.tolist()`, then pass `[par_list]` to flag_gaussians.

Now the list of flagged Gaussians is shorter. 
There is A LOT of differences in the .gaul file.