### PR TITLE
Speedup statistics for the Gaussian residual image

### DIFF
--- a/bdsf/make_residimage.py
+++ b/bdsf/make_residimage.py
@@ -87,7 +87,7 @@ class Op_make_residimage(Op):
 
         if img.opts.residual_stats_do:
             # Calculate some statistics for the Gaussian residual image
-            resid_gaus_non_masked = resid_gaus[N.where(~N.isnan(img.ch0_arr))]
+            resid_gaus_non_masked = resid_gaus[~N.isnan(img.ch0_arr)]
             mean = N.mean(resid_gaus_non_masked, axis=None)
             std_dev = N.std(resid_gaus_non_masked, axis=None)
             skew = stats.skew(resid_gaus_non_masked, axis=None)


### PR DESCRIPTION
This is inspired by https://github.com/lofar-astron/PyBDSF/pull/306.
`N.where` is not needed here.
For 4k x 4k matrix it makes this block 1.47x faster.

BTW: this new option `residual_stats_do` is not present in https://pybdsf.readthedocs.io/en/latest/process_image.html#general-reduction-parameters.