### PR TITLE
Convert loaded image to native byteorder

### DIFF
--- a/bdsf/functions.py
+++ b/bdsf/functions.py
@@ -1073,6 +1073,17 @@ def get_kwargs(kwargs, key, typ, default):
 
     return obj
 
+def mknative(a):
+    """
+    Convert array a to native byteorder and return
+    """
+    if a.dtype.isnative:
+        return a
+    else:
+        # Strip the byte order from dtype string
+        nobodtype = str(a.dtype)[1:]
+        return a.astype("="+nobodtype)
+
 def read_image_from_file(filename, img, indir, quiet=False):
     """ Reads data and header from indir/filename.
 
@@ -1314,6 +1325,7 @@ def read_image_from_file(filename, img, indir, quiet=False):
         data.shape = data.shape[0:4] # trim unused dimensions (if any)
         data = data.reshape(shape_out) # Add axes if needed
 
+    data = mknative(data)
     mylog.info("Final data shape (npol, nchan, x, y): " + str(data.shape))
 
     return data, hdr


### PR DESCRIPTION
Makes a small (but repeatable) performance improvement of around 10% on intel/amd architecture for the SKA ref case I have and also allows use libraries which do not handle non-native byteorder. (NB Fits are always big-endian)