### PR TITLE
Fix island pixel counting in `rmsimage.py` validation check

### DIFF
--- a/bdsf/islands.py
+++ b/bdsf/islands.py
@@ -234,10 +234,10 @@ class Op_islands(Op):
             mean = img.mean_arr
             labels = func.make_src_mask(image.shape, isl_posn_pix, isl_radius_pix)
             if img.masked:
-                aper_mask = N.where(labels.astype(bool) & ~mask)
+                aper_mask = labels.astype(bool) & ~mask
             else:
-                aper_mask = N.where(labels.astype(bool))
-            if N.size(aper_mask) >= img.minpix_isl and N.size(aper_mask) <= img.maxpix_isl:
+                aper_mask = labels.astype(bool)
+            if aper_mask.sum() >= img.minpix_isl and aper_mask.sum() <= img.maxpix_isl:
                 labels[aper_mask] = idx
                 s = [slice(max(0, isl_posn_pix[0] - isl_radius_pix - 1),
                      min(image.shape[0], isl_posn_pix[0] + isl_radius_pix + 1)),


### PR DESCRIPTION
**Bug**
`N.where()` returns a tuple of coordinate arrays (one for each dimension). When passed to `N.size()`, we get (dimensions * pixel_count), so e.g., double of the actual pixel count for a 2D image.

**Fix**
Ditch `N.where()` to keep aper_mask as a boolean mask, and use .sum() to get the true pixel count.

This also may be rare, since for my 1.5 GB test image the .gaul files are identical.