### PR TITLE
Fix mean value computation in `rmsimage.py`

### DIFF
--- a/bdsf/rmsimage.py
+++ b/bdsf/rmsimage.py
@@ -899,7 +899,7 @@ class Op_rmsimage(Op):
                 goodcutout = cutout[cutout != magic]
                 num_unmasked = len(goodcutout)
                 if num_unmasked > 0:
-                    themap[x, y] = np.nansum(goodcutout)/float(len(goodcutout))
+                    themap[x, y] = np.nanmean(goodcutout)
                 delx += 1
                 dely += 1
         themap[np.where(np.isnan(themap))] = 0.0


### PR DESCRIPTION
If `goodcutout` has NaN-s, np.nansum will reject them, but len() will include them. Consequently, the computed mean value will be too low.

for my 1.5 GB FITS test image the .gaul files are identical after this.