### PR TITLE
Remove duplicate from `opts.py`

### DIFF
--- a/bdsf/opts.py
+++ b/bdsf/opts.py
@@ -1137,10 +1137,6 @@ class Opts(object):
                              doc = "Restrict sources to "\
                                  "be only of type 'S'",
                              group = "psf_vary_do")
-    psf_stype_only = Bool(True,
-                             doc = "Restrict sources to "\
-                                 "be only of type 'S'",
-                             group = "psf_vary_do")
     psf_fwhm = Option(None, Tuple(Float(), Float(), Float()),
                              doc = "FWHM of the PSF. Specify as (maj, "\
                                  "min, pos ang E of N) in degrees. "\


### PR DESCRIPTION
The same is just above this.
The test is failing for unrelated reasons.
It's strange that the tests are failing though, as nothing has been changed since the last merged PR.
**EDIT**: 99% this is becouse they released numpy 2.5 yesterday.