### PR TITLE
Turn on multi-threading for the wavelet convolve

### DIFF
--- a/bdsf/wavelet_atrous.py
+++ b/bdsf/wavelet_atrous.py
@@ -323,7 +323,8 @@ class Op_wavelet_atrous(Op):
         kern = N.outer(ff, ff)
         unmasked = N.nan_to_num(image)
         if use_scipy_fft:
-            im_new = scipy.signal.fftconvolve(unmasked, kern, mode='same')
+            with scipy.fft.set_workers(8):
+                im_new = scipy.signal.fftconvolve(unmasked, kern, mode='same')
         else:
             im_new = fftconvolve(unmasked, kern, mode='same', pad_to_power_of_two=False, numcores=numcores)
         if im_new.shape != image.shape:

--- a/bdsf/wavelet_atrous.py
+++ b/bdsf/wavelet_atrous.py
@@ -323,7 +323,7 @@ class Op_wavelet_atrous(Op):
         kern = N.outer(ff, ff)
         unmasked = N.nan_to_num(image)
         if use_scipy_fft:
-            with scipy.fft.set_workers(8):
+            with scipy.fft.set_workers(numcores):
                 im_new = scipy.signal.fftconvolve(unmasked, kern, mode='same')
         else:
             im_new = fftconvolve(unmasked, kern, mode='same', pad_to_power_of_two=False, numcores=numcores)


### PR DESCRIPTION
This enables multithreading already built in in scipy's pocketfft/ducc. It improves the performance of the wavelet calculation by about factor of 4 and overall performance for my SKA reference run by about 14%. 

I've fixed workers at 8 here since that seems to saturate the memory bus on testing CPUs yet isnt large number. Could be made variable.