### PR TITLE
Fine-tune Gaussian fitting

### DIFF
--- a/bdsf/functions.py
+++ b/bdsf/functions.py
@@ -543,7 +543,9 @@ def trans_gaul(q):
 def momanalmask_gaus(subim, mask, isrc, bmar_p, allpara=True):
     """ Compute 2d gaussian parameters from moment analysis, for an island with
         multiple gaussians. Compute only for gaussian with index (mask value) isrc.
-        Returns normalised peak, centroid, fwhm and P.A. assuming North is top.
+        This is the final fallback in Gaussian fitting. Simply fits a single, broad
+        Gaussian to the remaining emission, which rarely gets flagged.
+        Returns normalised peak, centroid, FWHM and P.A. assuming North is top.
     """
     from math import sqrt, atan, pi
     from .const import fwsig

--- a/bdsf/gausfit.py
+++ b/bdsf/gausfit.py
@@ -365,7 +365,7 @@ class Op_gausfit(Op):
             ngmax = ng1+2
         if verbose:
             print('Initializing, ini_gausfit is', ini_gausfit, 'gaul =', gaul, 'ngmax =', ngmax)
-        while iter < 5:
+        while iter < 15:
             iter += 1
             if verbose:
                 print('In Gaussian flag loop, iter =', iter)
@@ -389,7 +389,7 @@ class Op_gausfit(Op):
             iter = 0
             ng1 = 0
             ngmax = 25
-            while iter < 5:
+            while iter < 15:
                 iter += 1
                 fitok = self.fit_iter(gaul, ng1, fcn, dof, beam, thr0, iter, 'simple', ngmax, verbose, g3_only)
                 gaul, fgaul = self.flag_gaussians(fcn.parameters, opts,
@@ -408,7 +408,7 @@ class Op_gausfit(Op):
             iter = 0
             ng1 = 0
             ngmax = 25
-            while iter < 5:
+            while iter < 15:
                 iter += 1
                 fitok = self.fit_iter(gaul, ng1, fcn, dof, beam, thr0, iter, 'simple', ngmax, verbose, g3_only)
                 gaul, fgaul = self.flag_gaussians(fcn.parameters, opts,
@@ -427,7 +427,7 @@ class Op_gausfit(Op):
             iter = 0
             ng1 = 0
             ngmax = 25
-            while iter < 5:
+            while iter < 15:
                 iter += 1
                 fitok = self.fit_iter(gaul, ng1, fcn, dof, beam, thr0, iter, 'simple', ngmax, verbose, g3_only)
                 gaul, fgaul = self.flag_gaussians(fcn.parameters, opts,


### PR DESCRIPTION
Originally, if the algorithm failed to converge after 5 iterations, it resorted to fallback methods. The final fallback, moment analysis (`func.momanalmask_gaus`), simply fits a single, broad Gaussian to the remaining emission, which rarely gets flagged.  By increasing the limit to 15 iterations, we prevent this oversimplification. The algorithm now models complex islands with multiple Gaussians. As a byproduct, a few components might get flagged.

The 5 iteration limit is 15y old, now the computers are much faster.