### PR TITLE
Fix external mask in `list_and_sort_gaussians`

### DIFF
--- a/bdsf/output.py
+++ b/bdsf/output.py
@@ -935,7 +935,9 @@ def list_and_sort_gaussians(img, patch=None, root=None,
                 gausflux = []
                 gausindx = []
             if use_mask:
-                patchnums.append(mask_labels[g.centre_pix[0], g.centre_pix[1]])
+                x_pix = int(round(g.centre_pix[0]))
+                y_pix = int(round(g.centre_pix[1]))
+                patchnums.append(mask_labels[y_pix, x_pix])
 
         if patch == 'source':
             sorted_gauslist = list(gauslist)

--- a/bdsf/output.py
+++ b/bdsf/output.py
@@ -927,9 +927,9 @@ def list_and_sort_gaussians(img, patch=None, root=None,
                 gausflux = []
                 gausindx = []
             if use_mask:
-                x_pix = int(round(g.centre_pix[0]))
-                y_pix = int(round(g.centre_pix[1]))
-                patchnums.append(mask_labels[y_pix, x_pix])
+                x_pix = round(g.centre_pix[0])
+                y_pix = round(g.centre_pix[1])
+                patchnums.append(mask_labels[x_pix, y_pix])
 
         if patch == 'source':
             sorted_gauslist = list(gauslist)


### PR DESCRIPTION
1) `g.centre_pix` is a float, so it must be rounded before used for indexing.
2) From `make_casa_str` we see that the order in `g.centre_pix` is (x, y). But in Numpy the arrays are (row, column), so this order must be inverted.