### PR TITLE
Fix external mask in `list_and_sort_gaussians` (2)

### DIFF
--- a/bdsf/output.py
+++ b/bdsf/output.py
@@ -977,7 +977,7 @@ def list_and_sort_gaussians(img, patch=None, root=None,
                           'included in the output sky model.')
         for p in unique_patch_ids:
             if p != 0:
-                in_patch = N.where(patchnums == p)
+                in_patch = N.where(N.array(patchnums) == p)
                 outlist.append(N.array(gauslist)[in_patch].tolist())
                 outnames.append(N.array(gausname)[in_patch].tolist())
                 patchnames.append('patch_'+str(p))


### PR DESCRIPTION
**Bug**
Because `patchnums` is a standard Python list and p is an integer, `patchnums == p` does not check individual elements. Instead, it instantly evaluates to a single boolean False.

**Consequences**
NumPy forbid evaluating 0-dimensional scalars. Passing False to N.where() crashes the script with `ValueError: Calling nonzero on 0d arrays is not allowed`.

**Fix**
Cast the list to a NumPy array to force an element-by-element evaluation