### PR TITLE
Make `mapcoord_threaded` faster

### DIFF
--- a/bdsf/rmsimage.py
+++ b/bdsf/rmsimage.py
@@ -66,7 +66,7 @@ def mapcoord_threaded(a, axs, *args, ncores=None, **kwargs):
 
 
     if ncores is None:
-        ncores = min(32, (mp.nproc or 1) + 4)
+        ncores = mp.nproc()
 
     output = kwargs.pop("output", None)
     order = kwargs.get("order", 3)

--- a/bdsf/rmsimage.py
+++ b/bdsf/rmsimage.py
@@ -65,8 +65,9 @@ def mapcoord_threaded(a, axs, *args, ncores=None, **kwargs):
         )
 
 
+    available_cpus = len(os.sched_getaffinity(0))
     if ncores is None:
-        ncores = min(32, (os.cpu_count() or 1) + 4)
+        ncores = min(32, (available_cpus or 1) + 4)
 
     output = kwargs.pop("output", None)
     order = kwargs.get("order", 3)

--- a/bdsf/rmsimage.py
+++ b/bdsf/rmsimage.py
@@ -76,8 +76,8 @@ def mapcoord_threaded(a, axs, *args, ncores=8, **kwargs):
     if order > 1:
         a = ndimage.spline_filter(a, order, output=np.float64, mode=mode)
 
-    # Fallback for non-2D cases
-    if len(axs) != 2:
+    # Fallback for 3D cases
+    if len(axs) > 2:
         if output is None:
             shape = [len(axs[1]), len(axs[0])] + [len(ax) for ax in axs[2:]]
             out_dtype = np.float64 if order > 1 else a.dtype

--- a/bdsf/rmsimage.py
+++ b/bdsf/rmsimage.py
@@ -80,11 +80,11 @@ def mapcoord_threaded(a, axs, *args, ncores=8, **kwargs):
     # Limit the tile size: 
     # max 1000: to avoid evicting data from the CPU L3 cache (~16 MB)
     # min 100:  so the Python array creation overhead doesn't exceed computation time
-    TILE_SIZE = max(100, min(1000, ideal_tile_size))
+    tile_size = max(100, min(1000, ideal_tile_size))
     
     # Generate coordinate ranges for individual tiles
-    ranges_0 = [(i, min(i + TILE_SIZE, len0)) for i in range(0, len0, TILE_SIZE)]
-    ranges_1 = [(i, min(i + TILE_SIZE, len1)) for i in range(0, len1, TILE_SIZE)]
+    ranges_0 = [(i, min(i + tile_size, len0)) for i in range(0, len0, tile_size)]
+    ranges_1 = [(i, min(i + tile_size, len1)) for i in range(0, len1, tile_size)]
     
     # Prepare coordinate pairs to eliminate task assignment delays
     tasks = [(r0, r1) for r1 in ranges_1 for r0 in ranges_0]

--- a/bdsf/rmsimage.py
+++ b/bdsf/rmsimage.py
@@ -67,7 +67,7 @@ def mapcoord_threaded(a, axs, *args, ncores=None, **kwargs):
 
     available_cpus = len(os.sched_getaffinity(0))
     if ncores is None:
-        ncores = min(32, (available_cpus or 1) + 4)
+        ncores = min(32, (mp.nproc or 1) + 4)
 
     output = kwargs.pop("output", None)
     order = kwargs.get("order", 3)

--- a/bdsf/rmsimage.py
+++ b/bdsf/rmsimage.py
@@ -65,7 +65,6 @@ def mapcoord_threaded(a, axs, *args, ncores=None, **kwargs):
         )
 
 
-    available_cpus = len(os.sched_getaffinity(0))
     if ncores is None:
         ncores = min(32, (mp.nproc or 1) + 4)
 

--- a/bdsf/rmsimage.py
+++ b/bdsf/rmsimage.py
@@ -35,10 +35,10 @@ def mapcoord_threaded(a, axs, *args, ncores=8, **kwargs):
     if ncores is None:
         ncores = min(32, (os.cpu_count() or 1) + 4)
 
-    output = kwargs.get("output", None)
-    kwargs["output"] = None
-    # Prefilter only once to awoid repeated work in the workers. See
-    # _interpolation.py in scipy
+    # Retrieve output and remove it from kwargs to manage it manually
+    output = kwargs.pop("output", None)
+    
+    # Pre-filtering performed once
     order = kwargs.get("order", 3)
     if order > 1:
         a = ndimage.spline_filter(a, order,
@@ -47,34 +47,42 @@ def mapcoord_threaded(a, axs, *args, ncores=8, **kwargs):
 
     if ncores <= 1:
         cl = np.meshgrid( * ([axs[0]]+axs[1:]))[-1::-1]
-        res = ndimage.map_coordinates(a,
-                                       cl,
-                                       prefilter=False,
-                                       *args, **kwargs)
-    else:
-        # Split axs[0] into chunks, one for each worker.
-        # This reduces thread overhead and maximizes parallel execution in C.
-        chunks = np.array_split(axs[0], ncores)
+        res = ndimage.map_coordinates(a, cl, prefilter=False, output=output, *args, **kwargs)
+        return res
 
-        def tworker(cl1):
-            # Construct the subset of meshgrid to which worker has been
-            # applied.
-            # NB: The axis reversal is specific to this program. The indexing parameter
-            # does not do exactly the same thing
-            cl = np.meshgrid( * ([cl1]+axs[1:]))[-1::-1]
-            return ndimage.map_coordinates(a,
-                                           cl,
-                                           # NB we pulled the pre-filter out
-                                           prefilter=False,
-                                           *args, **kwargs)
+    # Calculate chunk sizes
+    chunks = np.array_split(axs[0], ncores)
+    
+    # Pre-allocation - avoids np.hstack and np.copyto overhead
+    if output is None:
+        # Meshgrid with default indexing 'xy' returns a grid with shape (len(y), len(x))
+        shape = [len(axs[1]), len(axs[0])] + [len(ax) for ax in axs[2:]]
+        out_dtype = np.float64 if order > 1 else a.dtype
+        output = np.empty(shape, dtype=out_dtype)
 
-        with ThreadPoolExecutor(max_workers=ncores) as te:
-            res = te.map(tworker, chunks)
-            res = np.hstack(list(res))
+    # Calculate starting and ending indices for each column chunk
+    chunk_sizes = [len(c) for c in chunks]
+    indices = [0] + np.cumsum(chunk_sizes).tolist()
 
-    if output is not None:
-        np.copyto(output, res)
-    return res
+    def tworker(i, cl1):
+        # Generate a subset of the meshgrid for the worker
+        cl = np.meshgrid( * ([cl1]+axs[1:]))[-1::-1]
+        start, end = indices[i], indices[i+1]
+        
+        # Create a slice view for the corresponding columns (axis=1)
+        out_slice = [slice(None)] * output.ndim
+        out_slice[1] = slice(start, end)
+        
+        # Write the result directly into target array (no need to return/concatenate results)
+        ndimage.map_coordinates(a, cl, prefilter=False, output=output[tuple(out_slice)], *args, **kwargs)
+
+    with ThreadPoolExecutor(max_workers=ncores) as te:
+        futures = [te.submit(tworker, i, chunk) for i, chunk in enumerate(chunks)]
+        for f in futures:
+            # Re-raise exceptions if any occurred in the threads
+            f.result()
+
+    return output
 
 
 class Op_rmsimage(Op):

--- a/bdsf/rmsimage.py
+++ b/bdsf/rmsimage.py
@@ -32,6 +32,39 @@ def mapcoord_threaded(a, axs, *args, ncores=8, **kwargs):
     to equivalent of meshgrid(*axs)
 
     """
+    def tworker_fallback(i, cl1):
+        cl = np.meshgrid(*([cl1]+axs[1:]))[-1::-1]
+        start, end = indices[i], indices[i+1]
+        out_slice = [slice(None)] * output.ndim
+        out_slice[1] = slice(start, end)
+        ndimage.map_coordinates(a, cl, prefilter=False, output=output[tuple(out_slice)], *args, **kwargs)
+
+    def tworker_tiled(r0, r1):
+        start0, end0 = r0
+        start1, end1 = r1
+        
+        sub_ax0 = ax0[start0:end0]
+        sub_ax1 = ax1[start1:end1]
+        
+        h = end1 - start1
+        w = end0 - start0
+        
+        # Allocate a contiguous float64 array and use 
+        # lossless numpy broadcasting
+        coords = np.empty((2, h, w), dtype=np.float64)
+        coords[0, :, :] = sub_ax1[:, None]  # Y-axis
+        coords[1, :, :] = sub_ax0[None, :]  # X-axis
+        
+        out_slice = (slice(start1, end1), slice(start0, end0))
+        
+        ndimage.map_coordinates(
+            a, coords, 
+            prefilter=False, 
+            output=output[out_slice], 
+            *args, **kwargs
+        )
+
+
     if ncores is None:
         ncores = min(32, (os.cpu_count() or 1) + 4)
 
@@ -53,13 +86,6 @@ def mapcoord_threaded(a, axs, *args, ncores=8, **kwargs):
         chunks = np.array_split(axs[0], ncores)
         chunk_sizes = [len(c) for c in chunks]
         indices = [0] + np.cumsum(chunk_sizes).tolist()
-
-        def tworker_fallback(i, cl1):
-            cl = np.meshgrid(*([cl1]+axs[1:]))[-1::-1]
-            start, end = indices[i], indices[i+1]
-            out_slice = [slice(None)] * output.ndim
-            out_slice[1] = slice(start, end)
-            ndimage.map_coordinates(a, cl, prefilter=False, output=output[tuple(out_slice)], *args, **kwargs)
 
         with ThreadPoolExecutor(max_workers=ncores) as te:
             futures = [te.submit(tworker_fallback, i, chunk) for i, chunk in enumerate(chunks)]
@@ -88,31 +114,6 @@ def mapcoord_threaded(a, axs, *args, ncores=8, **kwargs):
     
     # Prepare coordinate pairs to eliminate task assignment delays
     tasks = [(r0, r1) for r1 in ranges_1 for r0 in ranges_0]
-
-    def tworker_tiled(r0, r1):
-        start0, end0 = r0
-        start1, end1 = r1
-        
-        sub_ax0 = ax0[start0:end0]
-        sub_ax1 = ax1[start1:end1]
-        
-        h = end1 - start1
-        w = end0 - start0
-        
-        # Allocate a contiguous float64 array and use 
-        # lossless numpy broadcasting
-        coords = np.empty((2, h, w), dtype=np.float64)
-        coords[0, :, :] = sub_ax1[:, None]  # Y-axis
-        coords[1, :, :] = sub_ax0[None, :]  # X-axis
-        
-        out_slice = (slice(start1, end1), slice(start0, end0))
-        
-        ndimage.map_coordinates(
-            a, coords, 
-            prefilter=False, 
-            output=output[out_slice], 
-            *args, **kwargs
-        )
 
     # If the image is very small, run it in the main thread, 
     # bypassing ThreadPoolExecutor

--- a/bdsf/rmsimage.py
+++ b/bdsf/rmsimage.py
@@ -35,55 +35,96 @@ def mapcoord_threaded(a, axs, *args, ncores=8, **kwargs):
     if ncores is None:
         ncores = min(32, (os.cpu_count() or 1) + 4)
 
-    # Retrieve output and remove it from kwargs to manage it manually
     output = kwargs.pop("output", None)
-    
-    # Pre-filtering performed once
     order = kwargs.get("order", 3)
-    if order > 1:
-        a = ndimage.spline_filter(a, order,
-                                  output=np.float64,
-                                  mode=kwargs.get("mode", "constant"))
-
-    if ncores <= 1:
-        cl = np.meshgrid( * ([axs[0]]+axs[1:]))[-1::-1]
-        res = ndimage.map_coordinates(a, cl, prefilter=False, output=output, *args, **kwargs)
-        return res
-
-    # Calculate chunk sizes
-    chunks = np.array_split(axs[0], ncores)
+    mode = kwargs.get("mode", "constant")
     
-    # Pre-allocation - avoids np.hstack and np.copyto overhead
+    # Filter the original image only once in the main thread
+    if order > 1:
+        a = ndimage.spline_filter(a, order, output=np.float64, mode=mode)
+
+    # Fallback for non-2D cases
+    if len(axs) != 2:
+        if output is None:
+            shape = [len(axs[1]), len(axs[0])] + [len(ax) for ax in axs[2:]]
+            out_dtype = np.float64 if order > 1 else a.dtype
+            output = np.empty(shape, dtype=out_dtype)
+        
+        chunks = np.array_split(axs[0], ncores)
+        chunk_sizes = [len(c) for c in chunks]
+        indices = [0] + np.cumsum(chunk_sizes).tolist()
+
+        def tworker_fallback(i, cl1):
+            cl = np.meshgrid(*([cl1]+axs[1:]))[-1::-1]
+            start, end = indices[i], indices[i+1]
+            out_slice = [slice(None)] * output.ndim
+            out_slice[1] = slice(start, end)
+            ndimage.map_coordinates(a, cl, prefilter=False, output=output[tuple(out_slice)], *args, **kwargs)
+
+        with ThreadPoolExecutor(max_workers=ncores) as te:
+            futures = [te.submit(tworker_fallback, i, chunk) for i, chunk in enumerate(chunks)]
+            for f in futures:
+                f.result() # Re-raise exceptions if any occurred in the threads
+        return output
+
+    # Cache blocking (tiling)
+    ax0, ax1 = axs[0], axs[1]
+    len0, len1 = len(ax0), len(ax1)
+    
     if output is None:
-        # Meshgrid with default indexing 'xy' returns a grid with shape (len(y), len(x))
-        shape = [len(axs[1]), len(axs[0])] + [len(ax) for ax in axs[2:]]
-        out_dtype = np.float64 if order > 1 else a.dtype
-        output = np.empty(shape, dtype=out_dtype)
+        output = np.empty((len1, len0), dtype=np.float32)
 
-    # Calculate starting and ending indices for each column chunk
-    chunk_sizes = [len(c) for c in chunks]
-    indices = [0] + np.cumsum(chunk_sizes).tolist()
+    # Aim to split the image to generate enough tasks for all cores
+    ideal_tile_size = int(max(len0, len1) / (np.sqrt(ncores) or 1))
+    
+    # Limit the tile size: 
+    # max 1000: to avoid evicting data from the CPU L3 cache (~16 MB)
+    # min 100:  so the Python array creation overhead doesn't exceed computation time
+    TILE_SIZE = max(100, min(1000, ideal_tile_size))
+    
+    # Generate coordinate ranges for individual tiles
+    ranges_0 = [(i, min(i + TILE_SIZE, len0)) for i in range(0, len0, TILE_SIZE)]
+    ranges_1 = [(i, min(i + TILE_SIZE, len1)) for i in range(0, len1, TILE_SIZE)]
+    
+    # Prepare coordinate pairs to eliminate task assignment delays
+    tasks = [(r0, r1) for r1 in ranges_1 for r0 in ranges_0]
 
-    def tworker(i, cl1):
-        # Generate a subset of the meshgrid for the worker
-        cl = np.meshgrid( * ([cl1]+axs[1:]))[-1::-1]
-        start, end = indices[i], indices[i+1]
+    def tworker_tiled(r0, r1):
+        start0, end0 = r0
+        start1, end1 = r1
         
-        # Create a slice view for the corresponding columns (axis=1)
-        out_slice = [slice(None)] * output.ndim
-        out_slice[1] = slice(start, end)
+        sub_ax0 = ax0[start0:end0]
+        sub_ax1 = ax1[start1:end1]
         
-        # Write the result directly into target array (no need to return/concatenate results)
-        ndimage.map_coordinates(a, cl, prefilter=False, output=output[tuple(out_slice)], *args, **kwargs)
+        h = end1 - start1
+        w = end0 - start0
+        
+        # Allocate a contiguous float64 array and use 
+        # lossless numpy broadcasting
+        coords = np.empty((2, h, w), dtype=np.float64)
+        coords[0, :, :] = sub_ax1[:, None]  # Y-axis
+        coords[1, :, :] = sub_ax0[None, :]  # X-axis
+        
+        out_slice = (slice(start1, end1), slice(start0, end0))
+        
+        ndimage.map_coordinates(
+            a, coords, 
+            prefilter=False, 
+            output=output[out_slice], 
+            *args, **kwargs
+        )
 
-    with ThreadPoolExecutor(max_workers=ncores) as te:
-        futures = [te.submit(tworker, i, chunk) for i, chunk in enumerate(chunks)]
-        for f in futures:
-            # Re-raise exceptions if any occurred in the threads
-            f.result()
+    # If the image is very small, run it in the main thread, 
+    # bypassing ThreadPoolExecutor
+    if len(tasks) == 1:
+        tworker_tiled(tasks[0][0], tasks[0][1])
+    else:
+        with ThreadPoolExecutor(max_workers=ncores) as te:
+            futures = [te.submit(tworker_tiled, r0, r1) for r0, r1 in tasks]
+            for f in futures:
+                f.result() # Catches any potential exceptions raised in threads
 
     return output
-
 
 class Op_rmsimage(Op):
     """Calculate rms & noise maps

--- a/bdsf/rmsimage.py
+++ b/bdsf/rmsimage.py
@@ -32,6 +32,9 @@ def mapcoord_threaded(a, axs, *args, ncores=8, **kwargs):
     to equivalent of meshgrid(*axs)
 
     """
+    if ncores is None:
+        ncores = min(32, (os.cpu_count() or 1) + 4)
+
     output = kwargs.get("output", None)
     kwargs["output"] = None
     # Prefilter only once to awoid repeated work in the workers. See
@@ -42,25 +45,36 @@ def mapcoord_threaded(a, axs, *args, ncores=8, **kwargs):
                                   output=np.float64,
                                   mode=kwargs.get("mode", "constant"))
 
-    def tworker(cl1):
-        # Construct the subset of meshgrid to which worker has been
-        # applied.
-        # NB: The axis reversal is specific to this program. The indexing parameter
-        # does not do exactly the same thing
-        cl = np.meshgrid( * ([cl1]+axs[1:]))[-1::-1]
-        return ndimage.map_coordinates(a,
+    if ncores <= 1:
+        cl = np.meshgrid( * ([axs[0]]+axs[1:]))[-1::-1]
+        res = ndimage.map_coordinates(a,
                                        cl,
-                                       # NB we pulled the pre-filter out
                                        prefilter=False,
                                        *args, **kwargs)
+    else:
+        # Split axs[0] into chunks, one for each worker.
+        # This reduces thread overhead and maximizes parallel execution in C.
+        chunks = np.array_split(axs[0], ncores)
 
-    with ThreadPoolExecutor(max_workers=ncores) as te:
-        res=te.map(tworker,
-                   axs[0])
-        res=np.hstack(list(res))
-        if output is not None:
-            np.copyto(output, res)
-        return res
+        def tworker(cl1):
+            # Construct the subset of meshgrid to which worker has been
+            # applied.
+            # NB: The axis reversal is specific to this program. The indexing parameter
+            # does not do exactly the same thing
+            cl = np.meshgrid( * ([cl1]+axs[1:]))[-1::-1]
+            return ndimage.map_coordinates(a,
+                                           cl,
+                                           # NB we pulled the pre-filter out
+                                           prefilter=False,
+                                           *args, **kwargs)
+
+        with ThreadPoolExecutor(max_workers=ncores) as te:
+            res = te.map(tworker, chunks)
+            res = np.hstack(list(res))
+
+    if output is not None:
+        np.copyto(output, res)
+    return res
 
 
 class Op_rmsimage(Op):

--- a/bdsf/rmsimage.py
+++ b/bdsf/rmsimage.py
@@ -23,7 +23,7 @@ from .functions import read_image_from_file
 from . import multi_proc as mp
 
 
-def mapcoord_threaded(a, axs, *args, ncores=8, **kwargs):
+def mapcoord_threaded(a, axs, *args, ncores=None, **kwargs):
     """Threaded map_coordinates on cartesian coordinate grid (meshgrid)
 
     :param a: Array to be regridded


### PR DESCRIPTION
**Chunking to reduce thread overhead**
**Before**: The function submitted a separate thread task for every single coordinate element in `axs[0]`.
**After**: The coordinates are split into `ncores` larger blocks using `np.array_split(axs[0], ncores)`. This reduces scheduling overhead and context switching.

**No threading for single core**
When `ncores` <= 1, skip ThreadPoolExecutor.

**Vectorized C operations**
Running on larger multi-coordinate chunks allows SciPy to perform vector operations.

A non-2D fallback is necessary since the optimised version only works for 2D.

For a (19845, 19845) image, Xeon 6238R (28 cores):

Before:
```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
       28    0.001    0.000  244.910    8.747 /home/akurek/miniconda3/envs/pybdsf_3_14/lib/python3.14/site-packages/bdsf/rmsimage.py:26(mapcoord_threaded)
```
After:
```
       28    6.367    0.227   47.940    1.712 /home/akurek/miniconda3/envs/pybdsf_3_14/lib/python3.14/site-packages/bdsf/rmsimage.py:26(mapcoord_threaded)
```
5.1x faster.
The entire run is faster by ~15% if wavelets are on.
.gaul files are identical.