### PR TITLE
More robust statistics of a very small RMS window

### DIFF
--- a/bdsf/rmsimage.py
+++ b/bdsf/rmsimage.py
@@ -965,9 +965,18 @@ class Op_rmsimage(Op):
                 if cnt > 198: cm = m; cr = r
                 mean_map[i, j], rms_map[i, j] = cm, cr
             else:
-                if npix_unmasked > 5: # just find simple mean/rms
-                    cm = np.mean(arr[pix_unmasked])
-                    cr = np.std(arr[pix_unmasked])
+                if npix_unmasked > 5: # use robust median and MAD instead of mean/std
+                    valid_pixels = arr_slice[unmasked_mask]
+                    cm = np.median(valid_pixels)
+                    
+                    # Calculate standard deviation estimated from MAD
+                    # MAD = median(|x - median(x)|). The scale factor for a Gaussian distribution is 1.4826
+                    mad = np.median(np.abs(valid_pixels - cm))
+                    cr = 1.4826 * mad
+                    
+                    # Protection against zero noise (e.g. all pixels have the same value)
+                    if cr == 0.0:
+                        cr = np.std(valid_pixels) # final fallback
                     mean_map[i, j], rms_map[i, j] = cm, cr
                 else: # too few unmasked pixels --> set mean/rms to inf
                     mean_map[i, j], rms_map[i, j] = np.inf, np.inf
@@ -987,9 +996,18 @@ class Op_rmsimage(Op):
                 m, r, cm, cr, cnt = bstat(arr[a:b, c:d], mask[a:b, c:d], kappa)
                 if cnt > 198: cm = m; cr = r
             else:
-                if npix_unmasked > 5: # just find simple mean/rms
-                    cm = np.mean(arr[pix_unmasked])
-                    cr = np.std(arr[pix_unmasked])
+                if npix_unmasked > 5: # use robust median and MAD instead of mean/std
+                    valid_pixels = arr_slice[unmasked_mask]
+                    cm = np.median(valid_pixels)
+                    
+                    # Calculate standard deviation estimated from MAD
+                    # MAD = median(|x - median(x)|). The scale factor for a Gaussian distribution is 1.4826
+                    mad = np.median(np.abs(valid_pixels - cm))
+                    cr = 1.4826 * mad
+                    
+                    # Protection against zero noise (e.g. all pixels have the same value)
+                    if cr == 0.0:
+                        cr = np.std(valid_pixels) # final fallback
                 else: # too few unmasked pixels --> set mean/rms to inf
                     cm = np.inf
                     cr = np.inf

--- a/bdsf/rmsimage.py
+++ b/bdsf/rmsimage.py
@@ -966,14 +966,14 @@ class Op_rmsimage(Op):
                 mean_map[i, j], rms_map[i, j] = cm, cr
             else:
                 if npix_unmasked > 5: # use robust median and MAD instead of mean/std
-                    valid_pixels = arr_slice[unmasked_mask]
+                    # First take the same windows for which the mask was calculated
+                    # and then select only the unmasked pixels
+                    valid_pixels = arr[a:b, c:d][pix_unmasked]
                     cm = np.median(valid_pixels)
-                    
                     # Calculate standard deviation estimated from Median Absolute Deviation (MAD)
                     # MAD = median(|x - median(x)|). The scale factor for a Gaussian distribution is 1.4826
-                    mad = np.median(np.abs(valid_pixels - cm))
-                    cr = 1.4826 * mad
-                    
+                    cr = np.median(np.abs(valid_pixels - cm)) * 1.4826
+
                     # Protection against zero noise (e.g. all pixels have the same value)
                     if cr == 0.0:
                         cr = np.std(valid_pixels) # final fallback
@@ -996,14 +996,10 @@ class Op_rmsimage(Op):
                 m, r, cm, cr, cnt = bstat(arr[a:b, c:d], mask[a:b, c:d], kappa)
                 if cnt > 198: cm = m; cr = r
             else:
-                if npix_unmasked > 5: # use robust median and MAD instead of mean/std
-                    valid_pixels = arr_slice[unmasked_mask]
+                if npix_unmasked > 5: # same logic as in 'for_masked'
+                    valid_pixels = arr[a:b, c:d][pix_unmasked]
                     cm = np.median(valid_pixels)
-                    
-                    # Calculate standard deviation estimated from MAD
-                    # MAD = median(|x - median(x)|). The scale factor for a Gaussian distribution is 1.4826
-                    mad = np.median(np.abs(valid_pixels - cm))
-                    cr = 1.4826 * mad
+                    cr = np.median(np.abs(valid_pixels - cm)) * 1.4826
                     
                     # Protection against zero noise (e.g. all pixels have the same value)
                     if cr == 0.0:

--- a/bdsf/rmsimage.py
+++ b/bdsf/rmsimage.py
@@ -969,7 +969,7 @@ class Op_rmsimage(Op):
                     valid_pixels = arr_slice[unmasked_mask]
                     cm = np.median(valid_pixels)
                     
-                    # Calculate standard deviation estimated from MAD
+                    # Calculate standard deviation estimated from Median Absolute Deviation (MAD)
                     # MAD = median(|x - median(x)|). The scale factor for a Gaussian distribution is 1.4826
                     mad = np.median(np.abs(valid_pixels - cm))
                     cr = 1.4826 * mad


### PR DESCRIPTION
If a window contains very few unmasked pixels (between 6 and 20), the code abandons sigma clipping in favor of mean and standard deviation. This reduces robustness against sources in crowded regions (like probably the reference image in CI).

Solution: robust statistics that are less sensitive to outliers: median and Median Absolute Deviation (MAD). For distributions that are approximately Gaussian, the standard deviation can be estimated by multiplying MAD by 1.4826.

It prevents a single defective or contaminated pixel from distorting the RMS and mean map.

For my 20x x 20k test image the .gaul files are identical.