### PR TITLE
Fine-tune inverse of the complementary error function in `treshold.py`

### DIFF
--- a/bdsf/threshold.py
+++ b/bdsf/threshold.py
@@ -15,7 +15,7 @@ from __future__ import absolute_import
 import numpy as N
 from .image import Op, Image, NArray
 from math import sqrt,pi,log
-from scipy.special import erfc
+from scipy.special import erfc, erfcinv
 from . import const
 from . import mylogger
 
@@ -71,11 +71,8 @@ class Op_threshold(Op):
                 raise RuntimeError("FDR thresholding failed. Please check the input image for problems.")
             dumr1 = 1.0-2.0*pcrit
             dumr = 8.0/3.0/pi*(pi-3.0)/(4.0-pi)
-            # approx for inv(erfc)
-            sigcrit = sqrt(-2.0/pi/dumr-log(1.0-dumr1*dumr1)/2.0+  \
-                          sqrt((2.0/pi/dumr+log(1.0-dumr1*dumr1)/2.0)* \
-                          (2.0/pi/dumr+log(1.0-dumr1*dumr1)/2.0)-      \
-                          log(1.0-dumr1*dumr1)/dumr))*sq2
+            # Inverse of the complementary error function
+            sigcrit = erfcinv(2.0 * pcrit) * sq2
             if pcrit == 0.0:
                 img.thresh = 'hard'
             else:


### PR DESCRIPTION
Its better to use the modern scipy implementation.

Comparison script:
[compar.py](https://github.com/user-attachments/files/29671141/compar.py)

Results:
```
p-value (pcrit) | PyBDSF (Aprox.)    | SciPy              | Relative error (%)
---------------------------------------------------------------------------
1.0e-01         | 1.28105338         | 1.28155157         | 0.038874%
5.0e-02         | 1.64342123         | 1.64485363         | 0.087084%
1.0e-02         | 2.32136770         | 2.32634787         | 0.214077%
1.0e-03         | 3.08013212         | 3.09023231         | 0.326842%
1.0e-05         | 4.25126286         | 4.26489079         | 0.319538%
1.0e-07         | 5.18785287         | 5.19933758         | 0.220888%
1.0e-09         | 5.99017747         | 5.99780702         | 0.127206%
```

The error is small, but this is the very beginning of a run, so maybe it propagates further.