### PR TITLE
Remove backport to `shutil_get_terminal_size`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,6 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Astronomy",
 ]
 dependencies = [
-    "backports.shutil_get_terminal_size",
     "astropy",
     "numpy",
     "scipy",


### PR DESCRIPTION
This is not needed since Python 3.3:
https://pypi.org/project/backports.shutil_get_terminal_size/
It may event be shadowing the native `shutil_get_terminal_size`.