### PR TITLE
Fix extended source filtering in adaptive rms box calculation

### DIFF
--- a/bdsf/rmsimage.py
+++ b/bdsf/rmsimage.py
@@ -141,13 +141,13 @@ class Op_rmsimage(Op):
         image = ch0_images[0]
         shape = image.shape
         isl_size_bright = []
-        isl_area_highthresh = []
         threshold = start_thresh
         if do_adapt:
             mylogger.userinfo(mylog, "Using adaptive scaling of rms_box")
             while len(isl_size_bright) < 5 and threshold >= adapt_thresh:
                 isl_size_bright=[]
                 isl_maxposn = []
+                isl_area_highthresh = []
                 if img.masked:
                     act_pixels = ~(mask.copy())
                     act_pixels[~mask] = (image[~mask]-cmean)/threshold >= crms


### PR DESCRIPTION
Later the code assumes that the indices in these lists correspond to each other:

```
bright_indx = isl_maxposn.index(isl_maxposn_lowthresh)

isl_area_highthresh[bright_indx]
isl_size_bright[bright_indx]
```

Presently `isl_area_highthresh` is not cleaned at each iteration, so the computed island areas do not correspond to the correct islands.