### PR TITLE
Fix FDR algorithm

### DIFF
--- a/bdsf/threshold.py
+++ b/bdsf/threshold.py
@@ -60,12 +60,16 @@ class Op_threshold(Op):
             for i in range(area_pix):
                 s0 +=  1.0/(i+1)
             slope = opts.fdr_alpha/s0
-            # sort erf of normalised image as vector
-            v = N.sort(0.5*erfc(N.ravel((data-img.mean_arr)/img.rms_arr)/sq2))[::-1]
+            # Sort p-values in ascending order for correct FDR implementation
+            v = N.sort(0.5*erfc(N.ravel((data-img.mean_arr)/img.rms_arr)/sq2))
             pcrit = None
-            for i,x in enumerate(v):
-                if x < slope*i/size:
-                    pcrit = x
+            
+            # Find the largest index k (from size down to 1) 
+            # such that p-value <= slope * k / size
+            for k in range(size, 0, -1):
+                # Benjamini-Yekutieli FDR condition
+                if v[k-1] <= slope * k / size:
+                    pcrit = v[k-1]
                     break
             if pcrit is None:
                 raise RuntimeError("FDR thresholding failed. Please check the input image for problems.")

--- a/bdsf/threshold.py
+++ b/bdsf/threshold.py
@@ -51,6 +51,7 @@ class Op_threshold(Op):
         else:
             img.thresh = img.opts.thresh
 
+        # https://iopscience.iop.org/article/10.1086/338316
         if img.thresh=='fdr':
             cdelt = img.wcs_obj.acdelt[:2]
             bm = (img.beam[0], img.beam[1])

--- a/bdsf/threshold.py
+++ b/bdsf/threshold.py
@@ -65,7 +65,7 @@ class Op_threshold(Op):
             v = N.sort(0.5*erfc(N.ravel((data-img.mean_arr)/img.rms_arr)/sq2))
             pcrit = None
             
-            # Find the largest index k (from size down to 1) 
+            # Find the largest index k (from 'size' down to 1) 
             # such that p-value <= slope * k / size
             for k in range(size, 0, -1):
                 # Benjamini-Yekutieli FDR condition


### PR DESCRIPTION
The code sorted the p-values in descending order, so it evaluated the wrong condition. This broke the FDR, turning it into a flawed hard threshold that allowed too many false positive pixels (noise).

Fix: Sort the p-values in ascending order and iterate backward (from the total number of pixels N down to 1) to find the largest index k that satisfies Benjamini-Yekutieli FDR condition.