### PR TITLE
Add warning to `treshold.py`

### DIFF
--- a/bdsf/threshold.py
+++ b/bdsf/threshold.py
@@ -101,6 +101,8 @@ class Op_threshold(Op):
         for i,s in enumerate(scflux):
             if s < smin_L:
                 index = i
+                mylogger.userinfo(mylog, "Detection threshold lies outside the calibrated source-count range.")
+                mylogger.userinfo(mylog, "Source count estimate is extrapolated.")
                 break
         n1 = scnum[index]; n2 = scnum[-1]
         s1 = scflux[index]; s2 = scflux[-1]

--- a/bdsf/threshold.py
+++ b/bdsf/threshold.py
@@ -34,7 +34,7 @@ class Op_threshold(Op):
         sq2  = sqrt(2)
 
         if img.opts.thresh is None:
-            source_p = self.get_srcp(img)
+            source_p = self.get_srcp(img, mylog)
             cutoff = 5.0
             false_p = 0.5*erfc(cutoff/sq2)*size
             if false_p < opts.fdr_ratio*source_p:
@@ -84,7 +84,7 @@ class Op_threshold(Op):
         img.completed_Ops.append('threshold')
         return img
 
-    def get_srcp(self, img):
+    def get_srcp(self, img, mylog):
         from . import sourcecounts as sc
         fwsig = const.fwsig
         cutoff = 5.0

--- a/bdsf/threshold.py
+++ b/bdsf/threshold.py
@@ -102,7 +102,7 @@ class Op_threshold(Op):
             if s < smin_L:
                 index = i
                 mylogger.userinfo(mylog, "Detection threshold lies outside the calibrated source-count range.")
-                mylogger.userinfo(mylog, "Source count estimate is extrapolated.")
+                mylogger.userinfo(mylog, "Source count estimate in threshold method selection is extrapolated.")
                 break
         n1 = scnum[index]; n2 = scnum[-1]
         s1 = scflux[index]; s2 = scflux[-1]

--- a/bdsf/threshold.py
+++ b/bdsf/threshold.py
@@ -99,8 +99,8 @@ class Op_threshold(Op):
         for i,s in enumerate(scflux):
             if s < smin_L:
                 index = i
-                mylogger.userinfo(mylog, "Detection threshold lies outside the calibrated source-count range.")
-                mylogger.userinfo(mylog, "Source count estimate in threshold method selection is extrapolated.")
+                mylogger.warning(mylog, "Detection threshold lies outside the calibrated source-count range.")
+                mylogger.warning(mylog, "Source count estimate in threshold method selection is extrapolated.")
                 break
         n1 = scnum[index]; n2 = scnum[-1]
         s1 = scflux[index]; s2 = scflux[-1]

--- a/bdsf/threshold.py
+++ b/bdsf/threshold.py
@@ -23,8 +23,11 @@ class Op_threshold(Op):
 
     Prerequisites: Module preprocess and rmsimage should be run first.
     """
+    def __init__(self):
+        self.logger = None
+
     def __call__(self, img):
-        mylog = mylogger.logging.getLogger("PyBDSF."+img.log+"Threshold ")
+        self.logger = mylogger.logging.getLogger("PyBDSF."+img.log+"Threshold ")
         data = img.ch0_arr
         mask = img.mask_arr
         opts = img.opts
@@ -48,20 +51,20 @@ class Op_threshold(Op):
             size = N.prod(data.shape)
 
         if img.opts.thresh is None:
-            source_p = self.get_srcp(img, mylog)
+            source_p = self.get_srcp(img)
             cutoff = 5.0
             false_p = 0.5*erfc(cutoff/sq2)*size
             if false_p < opts.fdr_ratio*source_p:
                 img.thresh = 'hard'
-                mylogger.userinfo(mylog, "Expected 5-sigma-clipped false detection rate < fdr_ratio")
-                mylogger.userinfo(mylog, "Using sigma-clipping ('hard') thresholding")
+                mylogger.userinfo(self.logger, "Expected 5-sigma-clipped false detection rate < fdr_ratio")
+                mylogger.userinfo(self.logger, "Using sigma-clipping ('hard') thresholding")
             else:
                 img.thresh = 'fdr'
-                mylogger.userinfo(mylog, "Expected 5-sigma-clipped false detection rate > fdr_ratio")
-                mylogger.userinfo(mylog, "Using FDR (False Detection Rate) thresholding")
-                mylog.debug('%s %g' % ("Estimated number of source pixels (using sourcecounts.py) is ",source_p))
-                mylog.debug('%s %g' % ("Number of false positive pixels expected for 5-sigma is ",false_p))
-                mylog.debug("Threshold for pixels set to : "+str.swapcase(img.thresh))
+                mylogger.userinfo(self.logger, "Expected 5-sigma-clipped false detection rate > fdr_ratio")
+                mylogger.userinfo(self.logger, "Using FDR (False Detection Rate) thresholding")
+                self.logger.debug('%s %g' % ("Estimated number of source pixels (using sourcecounts.py) is ",source_p))
+                self.logger.debug('%s %g' % ("Number of false positive pixels expected for 5-sigma is ",false_p))
+                self.logger.debug("Threshold for pixels set to : "+str.swapcase(img.thresh))
         else:
             img.thresh = img.opts.thresh
 
@@ -95,14 +98,14 @@ class Op_threshold(Op):
                 img.thresh = 'hard'
             else:
                 img.thresh_pix = sigcrit
-                mylogger.userinfo(mylog, "FDR threshold (replaces thresh_pix)", str(round(sigcrit, 4)))
+                mylogger.userinfo(self.logger, "FDR threshold (replaces thresh_pix)", str(round(sigcrit, 4)))
         else:
             img.thresh_pix = opts.thresh_pix
 
         img.completed_Ops.append('threshold')
         return img
 
-    def get_srcp(self, img, mylog):
+    def get_srcp(self, img):
         from . import sourcecounts as sc
         fwsig = const.fwsig
         cutoff = 5.0
@@ -119,8 +122,8 @@ class Op_threshold(Op):
         for i,s in enumerate(scflux):
             if s < smin_L:
                 index = i
-                mylogger.warning(mylog, "Detection threshold lies outside the calibrated source-count range.")
-                mylogger.warning(mylog, "Source count estimate in threshold method selection is extrapolated.")
+                self.logger.warning("Detection threshold lies outside the calibrated source-count range.")
+                self.logger.warning("Source count estimate in threshold method selection is extrapolated.")
                 break
         n1 = scnum[index]; n2 = scnum[-1]
         s1 = scflux[index]; s2 = scflux[-1]


### PR DESCRIPTION
Add:

> mylogger.userinfo(mylog, "Detection threshold lies outside the calibrated source-count range.")
> mylogger.userinfo(mylog, "Source count estimate in threshold method selection is extrapolated.")

It would be good to see how often this happens in the LOFAR era (the used model is very old).
Eg. it happens for my test image.