### PR TITLE
Fix coordinate offsets for extended sources

### DIFF
--- a/bdsf/gaul2srl.py
+++ b/bdsf/gaul2srl.py
@@ -359,7 +359,10 @@ class Op_gaul2srl(Op):
                 maxpeak = para[0]
             else:
                 maxpeak = maxv
-            posn = para[1:3]-(0.5*N.sum(s_imsize)-1)/2.0+N.array([maxx, maxy])-1+delc
+            # Calculate the sub-image center independently for X and Y axes
+            subim_center = (N.array(s_imsize, dtype=N.float32) - 1) / 2.0
+            # subim_center is a vector [center_X, center_Y], e.g., [4.5, 9.5]
+            posn = para[1:3] - subim_center + N.array([maxx, maxy]) - 1 + delc
         else:
             maxpeak = maxv
             posn = N.unravel_index(N.argmax(data*~rmask), data.shape)+N.array(delc) +blc


### PR DESCRIPTION
This improves astrometry for multi-component sources.

The intention was to create a square, but due to boundary effects these subimages are not always square.
The happens when the emission peak is located close to the edge of the island.

Eg.:
width of the island = 10
maxx = 8
maxy = 5
ssubimsize = 7

X axis:
blc[0] = max(0, 8 - 3) = 5
trc[0] = min(10, 8 + 3) = 10
X dimension: 10 - 5 + 1 = 6 (the boundary truncates the window by one pixel).

Y axis:
blc[1] = max(0, 5 - 3) = 2
trc[1] = min(10, 5 + 3) = 8
Y dimension: 8 - 2 + 1 = 7.

`s_imsize` will be [6, 7], so no longer square.