### PR TITLE
Fix formatting of `beam_spectrum` option in `print_opts()`

### DIFF
--- a/bdsf/interface.py
+++ b/bdsf/interface.py
@@ -752,6 +752,7 @@ def round_list_of_tuples(val):
     valstr_list = []
     valstr_list_tot = []
     for l in val:
+        valstr_list = []
         for v in l:
             vstr = '%s' % (round(v, 5))
             if len(vstr) > 7:


### PR DESCRIPTION
Reset the temporary list in round_list_of_tuples() to correctly format multiple tuples.