### PR TITLE
Fix: subtract background when computing `total_flux`

### DIFF
--- a/bdsf/islands.py
+++ b/bdsf/islands.py
@@ -350,8 +350,11 @@ class Island(object):
         in_bbox_and_unmasked = N.where(~N.isnan(bbox_mean_im))
         self.mean = bbox_mean_im[in_bbox_and_unmasked].mean()
         self.islmean = bbox_mean_im[in_bbox_and_unmasked].mean()
-        valid_pixels = ~self.mask_active & ~N.isnan(self.image) # pixels that are both: inside the island and not NaN
-        self.total_flux = N.nansum(self.image[valid_pixels])/beamarea
+        # Create a mask for pixels that are:
+        # a) within the island
+        # b) not NaN in both the image and the background map
+        valid_pixels = ~self.mask_active & ~N.isnan(self.image) & ~N.isnan(bbox_mean_im)
+        self.total_flux = N.nansum((self.image - bbox_mean_im)[valid_pixels]) / beamarea
         pixels_in_isl = N.sum(~N.isnan(self.image[~self.mask_active]))  # number of unmasked pixels assigned to current island
         self.total_fluxE = func.nanmean(bbox_rms_im[in_bbox_and_unmasked]) * N.sqrt(pixels_in_isl/beamarea)  # Jy
         self.border = self.get_border()

--- a/bdsf/islands.py
+++ b/bdsf/islands.py
@@ -354,11 +354,9 @@ class Island(object):
         self.shape = data.shape
         self.size_active = isl_size
         self.max_value = N.max(self.image[~self.mask_active])
-        in_bbox_and_unmasked = N.where(~N.isnan(bbox_rms_im))
-        self.rms = bbox_rms_im[in_bbox_and_unmasked].mean()
-        in_bbox_and_unmasked = N.where(~N.isnan(bbox_mean_im))
-        self.mean = bbox_mean_im[in_bbox_and_unmasked].mean()
-        self.islmean = bbox_mean_im[in_bbox_and_unmasked].mean()
+        self.rms = N.nanmean(bbox_rms_im)
+        self.mean = N.nanmean(bbox_mean_im)
+        self.islmean = self.mean
         # Create a mask for pixels that are:
         # a) within the island
         # b) not NaN in both the image and the background map


### PR DESCRIPTION
If the background is not subtracted, the calculated total flux of the island is usually slightly inaccurate.
<img width="800" height="500" alt="Figure_1" src="https://github.com/user-attachments/assets/81b1632c-bf1d-4bf8-9a46-b5f1d9341b14" />
