### PR TITLE
Fix island IDs map when `coords_to_isl` is used

### DIFF
--- a/bdsf/islands.py
+++ b/bdsf/islands.py
@@ -132,7 +132,16 @@ class Op_islands(Op):
             pyrank = N.zeros(ch0_shape, dtype=N.int32)
             for i, isl in enumerate(img.islands):
                 isl.island_id = i
-                pyrank[tuple(isl.bbox)] += N.invert(isl.mask_active) * (i + 1)
+                
+                # Get a boolean mask of the active pixels belonging to this specific island.
+                # In 'mask_active', True = background/masked, False = active island.
+                island_mask = N.invert(isl.mask_active)
+                
+                # Update the pyrank map slice
+                # For pixels where 'island_mask' is True, assign the new island ID (i + 1).
+                # For background pixels (False), preserve whatever values already exist in 'pyrank'
+                # at those coordinates, preventing ID accumulation on overlapping regions.
+                pyrank[tuple(isl.bbox)] = N.where(island_mask, i + 1, pyrank[tuple(isl.bbox)])
             pyrank -= 1  # align pyrank values with island ids and set regions outside of islands to -1
 
             img.pyrank = pyrank


### PR DESCRIPTION
**Problem**
The code uses the addition operator to assign island values. This fails in areas where islands overlap, as their ID values are summed instead of being overwritten.

**When it occurs**
When 2 or more islands overlap when constructing islands using `coords_to_isl`.

**Fix**
Replaced the addition with `numpy.where`. This ensures that overlapping pixels are overwritten with the latest island ID instead of accumulating ID values.