### PR TITLE
Add nproc() method

### DIFF
--- a/bdsf/multi_proc.py
+++ b/bdsf/multi_proc.py
@@ -17,13 +17,21 @@ import traceback
 
 import numpy
 
-# Try to determine the number of CPU cores _available_ to the current process,
-# similar to what the Linux `nproc` command does. If that fails, return the
-# total number of CPU cores in the machine.
-try:
-    _ncpus = len(os.sched_getaffinity(0))
-except AttributeError:
-    _ncpus = multiprocessing.cpu_count()
+def nproc():
+    """
+    Return the number of CPU cores _available_ to the current process, similar
+    to what the Linux `nproc` command does. This can be less than the total
+    number of CPU cores in the machine.
+    NOTE: This function uses `os.sched_getaffinity()`, which is not available
+    on every OS. Use `os.cpu_count()` as fall-back; return 1 in the rare case
+    that `os.cpu_count()` returns `None`.
+    """
+    try:
+        return len(os.sched_getaffinity(0))
+    except AttributeError:
+        return os.cpu_count() or 1
+
+_ncpus = nproc()
 
 # PyBDSF currently relies on fork-style multiprocessing.
 # The spawn and forkserver start methods are not supported because


### PR DESCRIPTION
Added `nproc()` method to determine the number of CPUs _available_ to the current process. If that cannot be determined, then return the number of CPUs present in the system.