### PR TITLE
Fix TOCTOU race in directory creation

### DIFF
--- a/bdsf/cleanup.py
+++ b/bdsf/cleanup.py
@@ -34,7 +34,7 @@ class Op_cleanup(Op):
 
             from math import log10
             bdir = img.basedir + '/misc/'
-            if not os.path.isdir(bdir): os.makedirs(bdir, exist_ok=True)
+            os.makedirs(bdir, exist_ok=True)
             im_mean = img.clipped_mean
             im_rms = img.clipped_rms
             low = 1.1*abs(img.min_value)

--- a/bdsf/cleanup.py
+++ b/bdsf/cleanup.py
@@ -34,7 +34,7 @@ class Op_cleanup(Op):
 
             from math import log10
             bdir = img.basedir + '/misc/'
-            if not os.path.isdir(bdir): os.makedirs(bdir)
+            if not os.path.isdir(bdir): os.makedirs(bdir, exist_ok=True)
             im_mean = img.clipped_mean
             im_rms = img.clipped_rms
             low = 1.1*abs(img.min_value)

--- a/bdsf/functions.py
+++ b/bdsf/functions.py
@@ -1390,7 +1390,7 @@ def write_image_to_file(use, filename, image, img, outdir=None,
         send_fits_image(img.samp_client, img.samp_key, 'PyBDSF image', tfile.name)
     else:
         # Write image to FITS file
-        if outdir is None:
+        if not outdir:
             outdir = img.indir
         os.makedirs(outdir, exist_ok=True)
         outfilename = os.path.join(outdir, filename)

--- a/bdsf/functions.py
+++ b/bdsf/functions.py
@@ -1330,8 +1330,7 @@ def convert_casacore_header(casacore_image, tmpdir):
     except ImportError as err:
         import pyfits
 
-    if not os.path.exists(tmpdir):
-        os.makedirs(tmpdir)
+    os.makedirs(tmpdir, exist_ok=True)
     tfile = tempfile.NamedTemporaryFile(delete=False, dir=tmpdir)
     casacore_image.tofits(tfile.name)
     hdr = pyfits.getheader(tfile.name)
@@ -1393,8 +1392,7 @@ def write_image_to_file(use, filename, image, img, outdir=None,
         # Write image to FITS file
         if outdir is None:
             outdir = img.indir
-        if not os.path.exists(outdir) and outdir != '':
-            os.makedirs(outdir)
+        os.makedirs(outdir, exist_ok=True)
         outfilename = os.path.join(outdir, filename)
         if os.path.isfile(outfilename):
             if clobber:
@@ -1548,8 +1546,7 @@ def get_name(img, map_name):
         pi_text = 'I'
     suffix = '/w%i_%s/' % (img.j, pi_text)
     dir = img.tempdir + suffix
-    if not os.path.exists(dir):
-        os.makedirs(dir)
+    os.makedirs(dir, exist_ok=True)
     return dir + map_name + '.bin'
 
 def connect(mask):
@@ -2231,8 +2228,7 @@ def set_up_output_paths(opts):
         output_basedir = os.path.abspath(outdir)
 
     # Make the output directory if needed
-    if not os.path.exists(output_basedir):
-        os.makedirs(output_basedir)
+    os.makedirs(output_basedir, exist_ok=True)
 
     # Check that we have write permission to the base directory
     if not os.access(output_basedir, os.W_OK):

--- a/bdsf/make_residimage.py
+++ b/bdsf/make_residimage.py
@@ -68,7 +68,7 @@ class Op_make_residimage(Op):
                 resdir = img.basedir + '/wavelet/residual/'
             else:
                 resdir = img.basedir + '/residual/'
-            if not os.path.exists(resdir): os.makedirs(resdir)
+            os.makedirs(resdir, exist_ok=True)
             func.write_image_to_file(img.use_io, img.imagename + '.resid_gaus.fits', resid_gaus, img, resdir)
             mylog.info('%s %s' % ('Writing', resdir+img.imagename+'.resid_gaus.fits'))
         if img.opts.output_all or img.opts.savefits_modelim:
@@ -76,7 +76,7 @@ class Op_make_residimage(Op):
                 moddir = img.basedir + '/wavelet/model/'
             else:
                 moddir = img.basedir + '/model/'
-            if not os.path.exists(moddir): os.makedirs(moddir)
+            os.makedirs(moddir, exist_ok=True)
             func.write_image_to_file(img.use_io, img.imagename + '.model.fits', (img.ch0_arr - resid_gaus), img, moddir)
             mylog.info('%s %s' % ('Writing', moddir+img.imagename+'.model_gaus.fits'))
 

--- a/bdsf/output.py
+++ b/bdsf/output.py
@@ -20,8 +20,7 @@ class Op_outlist(Op):
             import os
             if len(img.gaussians) > 0:
                 dir = img.basedir + '/catalogues/'
-                if not os.path.exists(dir):
-                    os.makedirs(dir)
+                os.makedirs(dir, exist_ok=True)
                 self.write_bbs(img, dir)
                 self.write_lsm(img, dir)
                 self.write_gaul(img, dir)
@@ -32,8 +31,7 @@ class Op_outlist(Op):
                 self.write_ds9(img, dir, objtype='srl')
                 self.write_gaul_FITS(img, dir)
                 self.write_srl_FITS(img, dir)
-            if not os.path.exists(img.basedir + '/misc/'):
-                os.makedirs(img.basedir + '/misc/')
+            os.makedirs(img.basedir + '/misc/', exist_ok=True)
             self.write_opts(img, img.basedir + '/misc/')
             self.save_opts(img, img.basedir + '/misc/')
             img.completed_Ops.append('outlist')
@@ -827,8 +825,7 @@ def write_islands(img):
 
     # write out island properties for reference since achaar doesnt work.
     filename = img.basedir + '/misc/'
-    if not os.path.exists(filename):
-        os.makedirs(filename)
+    os.makedirs(filename, exist_ok=True)
     filename = filename + 'island_file'
 
     if img.j == 0:

--- a/bdsf/readimage.py
+++ b/bdsf/readimage.py
@@ -81,8 +81,7 @@ class Op_readimage(Op):
         if img.do_cache:
             mylog.info('Using disk caching.')
             tmpdir = os.path.join(img.outdir, img.parentname+'_tmp')
-            if not os.path.exists(tmpdir):
-                os.makedirs(tmpdir)
+            os.makedirs(tmpdir, exist_ok=True)
             img._tempdir_parent = TempDir(tmpdir)
             img.tempdir = TempDir(tempfile.mkdtemp(dir=tmpdir))
             import atexit, shutil
@@ -137,8 +136,7 @@ class Op_readimage(Op):
                     os.system("rm -fr " + img.basedir + '/*')
 
             # Make the final output directory
-            if not os.path.exists(img.basedir):
-                os.makedirs(img.basedir)
+            os.makedirs(img.basedir, exist_ok=True)
 
         del data
         img.completed_Ops.append('readimage')

--- a/bdsf/rmsimage.py
+++ b/bdsf/rmsimage.py
@@ -380,7 +380,7 @@ class Op_rmsimage(Op):
                         resdir = img.basedir + '/wavelet/background/'
                     else:
                         resdir = img.basedir + '/background/'
-                    if not os.path.exists(resdir): os.makedirs(resdir)
+                    os.makedirs(resdir, exist_ok=True)
                     func.write_image_to_file(img.use_io, img.imagename + '.rmsd_I.fits', rms, img, resdir)
                     mylog.info('%s %s' % ('Writing ', resdir+img.imagename+'.rmsd_I.fits'))
                 if opts.savefits_meanim or opts.output_all:
@@ -388,7 +388,7 @@ class Op_rmsimage(Op):
                         resdir = img.basedir + '/wavelet/background/'
                     else:
                         resdir = img.basedir + '/background/'
-                    if not os.path.exists(resdir): os.makedirs(resdir)
+                    os.makedirs(resdir, exist_ok=True)
                     func.write_image_to_file(img.use_io, img.imagename + '.mean_I.fits', mean, img, resdir)
                     mylog.info('%s %s' % ('Writing ', resdir+img.imagename+'.mean_I.fits'))
                 if opts.savefits_normim or opts.output_all:
@@ -396,7 +396,7 @@ class Op_rmsimage(Op):
                         resdir = img.basedir + '/wavelet/background/'
                     else:
                         resdir = img.basedir + '/background/'
-                    if not os.path.exists(resdir): os.makedirs(resdir)
+                    os.makedirs(resdir, exist_ok=True)
                     rms_nonzero = rms.copy()
                     rms_nonzero[rms <= 0.0] = np.nan
                     func.write_image_to_file(img.use_io, img.imagename + '.norm_I.fits', (image-mean)/rms_nonzero, img, resdir)

--- a/bdsf/wavelet_atrous.py
+++ b/bdsf/wavelet_atrous.py
@@ -52,12 +52,9 @@ class Op_wavelet_atrous(Op):
             mylog.info("Decomposing gaussian residual image into a-trous wavelets")
             bdir = img.basedir + '/wavelet/'
             if img.opts.output_all:
-                if not os.path.isdir(bdir):
-                    os.makedirs(bdir)
-                if not os.path.isdir(bdir + '/residual/'):
-                    os.makedirs(bdir + '/residual/')
-                if not os.path.isdir(bdir + '/model/'):
-                    os.makedirs(bdir + '/model/')
+                os.makedirs(bdir, exist_ok=True)
+                os.makedirs(bdir + '/residual/', exist_ok=True)
+                os.makedirs(bdir + '/model/', exist_ok=True)
             dobdsm = img.opts.atrous_bdsm_do
             filter = {'tr': {'size': 3, 'vec': [1. / 4, 1. / 2, 1. / 4], 'name': 'Triangle'},
                       'b3': {'size': 5, 'vec': [1. / 16, 1. / 4, 3. / 8, 1. / 4, 1. / 16], 'name': 'B3 spline'}}


### PR DESCRIPTION
Fixes #356

Concurrent `process_image()` calls sharing an output directory tree (e.g. SLURM array tasks writing to a common parent) can crash with `FileExistsError`. Directory creation throughout the package uses a check-then-create pattern:

```python
if not os.path.exists(d):
    os.makedirs(d)
```

which has a race window between the check and the call - see #356. This PR converts the remaining sites to `os.makedirs(d, exist_ok=True)`, which is already used in `islands.py` (#209) and avoids the race condition entirely. All lines changed are shown in the table below.

| File | Lines |
|---|---|
| `bdsf/functions.py` | 1334, 1397, 1552, 2235 |
| `bdsf/cleanup.py` | 37 |
| `bdsf/make_residimage.py` | 71, 79 |
| `bdsf/output.py` | 24, 36, 831 |
| `bdsf/readimage.py` | 85, 141 |
| `bdsf/rmsimage.py` | 383, 391, 399 |
| `bdsf/wavelet_atrous.py` | 56, 58, 60 |

Every site was already guarded by an existence check, so sequential behaviour is unchanged, meaning only the concurrent crash is removed. `exist_ok=True` still raises if the path exists as a non-directory, so genuine misconfigurations surface exactly as before. I've dropped the now-redundant `if not exists` guards to match the `islands.py` style (one line instead of two); happy to keep them if a minimal diff is preferred.

A TOCTOU race isn't reproducible deterministically, so no regression test is included. The existing suite exercises every touched path sequentially and confirms no behaviour change there. 