### PR TITLE
Fix `area_pix` calculation in FDR

### DIFF
--- a/bdsf/threshold.py
+++ b/bdsf/threshold.py
@@ -55,7 +55,7 @@ class Op_threshold(Op):
         if img.thresh=='fdr':
             cdelt = img.wcs_obj.acdelt[:2]
             bm = (img.beam[0], img.beam[1])
-            area_pix = int(round((N.prod(bm) * pi / (4.0*log(2.0))) / abs(N.prod(cdelt))))
+            area_pix = round(pi/(4.0*log(2.0)) * (N.prod(bm) / abs(N.prod(cdelt))))
             s0 = 0
             for i in range(area_pix):
                 s0 +=  1.0/(i+1)

--- a/bdsf/threshold.py
+++ b/bdsf/threshold.py
@@ -55,8 +55,7 @@ class Op_threshold(Op):
         if img.thresh=='fdr':
             cdelt = img.wcs_obj.acdelt[:2]
             bm = (img.beam[0], img.beam[1])
-            area_pix = int(round(N.prod(bm)/(abs(N.prod(cdelt))* \
-                                                      pi/(4.0*log(2.0)))))
+            area_pix = int(round((N.prod(bm) * pi / (4.0*log(2.0))) / abs(N.prod(cdelt))))
             s0 = 0
             for i in range(area_pix):
                 s0 +=  1.0/(i+1)


### PR DESCRIPTION
Misplaced parentheses caused $\frac{\pi}{4 \ln(2)}$ to be placed in the denominator.
The area of a 2D Gaussian beam is defined:
$$A_{\text{beam}} = \text{BMAJ} \cdot \text{BMIN} \cdot \frac{\pi}{4 \ln(2)}$$
To find the number of pixels per beam, we must divide this by the area of a single pixel:
$$\text{Pixels} = \frac{\text{BMAJ} \cdot \text{BMIN} \cdot \frac{\pi}{4 \ln(2)}}{\vert{}dx \cdot dy\vert{}}$$
However, due to the parenthesis in the denominator `(abs(...) * pi/...)`, the code divided by the Gaussian constant instead of multiplying. The formula evaluated to:

$$\text{Pixels} = \frac{\text{BMAJ} \cdot \text{BMIN}}{\vert{}dx \cdot dy\vert{} \cdot \frac{\pi}{4 \ln(2)}}$$

$\frac{\pi}{4 \ln(2)} \approx 1.133$, so dividing by instead of multiplying resulted in underestimating the number of pixels per beam by 22%.