### PR TITLE
Fix `nmax` calculation in shapelets by removing incorrect upper limit

### DIFF
--- a/bdsf/shapefit.py
+++ b/bdsf/shapefit.py
@@ -135,7 +135,7 @@ class Op_shapelets(Op):
         if fixed[2]==0:
             (n, m)=image.shape
             nmax=int(round(sqrt(1.0*n*n+m*m)/beam_pix[1]))-1
-            nmax=min(max(nmax*2+2,10),10)                      # totally ad hoc
+            nmax = max(nmax * 2 + 2, 10) # min. 10, no upper limit for now
             npix = N.prod(image.shape)-N.sum(mask)
             if nmax*nmax >= n*m : nmax = int(floor(sqrt(npix-1)))  # -1 is for when n*m is a perfect square
             if mode == 'fit':   # make sure npara <= npix


### PR DESCRIPTION
`min(max(X, A), B)` works as follows:
First, `max(X, 10)` ensures that the result is at least 10.
Then, `min(..., 10)` ensures that the result is at most 10.
As a result, `nmax` is always =10, and the previous calculations based on the island size and the beam width are discarded.

The following:
`(if nmax*nmax >= n*m: ... and if mode == 'fit': ...)`
already ensure that `nmax` does not become too large relative to the amount of data. Therefore, it is sufficient to keep only the lower bound.