### PR TITLE
Fix seconds formatting in `plotresults.py`

### DIFF
--- a/bdsf/plotresults.py
+++ b/bdsf/plotresults.py
@@ -700,7 +700,7 @@ def xy_to_radec_str(x, y):
     ra, dec = pix2sky([x, y])
 
     ra = ra2hhmmss(ra)
-    sra = str(ra[0]).zfill(2)+':'+str(ra[1]).zfill(2)+':'+str("%.1f" % (ra[2])).zfill(3)
+    sra = str(ra[0]).zfill(2)+':'+str(ra[1]).zfill(2)+':'+str("%.1f" % (ra[2])).zfill(4)
     dec = dec2ddmmss(dec)
     decsign = ('-' if dec[3] < 0 else '+')
     sdec = decsign+str(dec[0]).zfill(2)+':'+str(dec[1]).zfill(2)+':'+str("%.1f" % (dec[2])).zfill(3)


### PR DESCRIPTION
zfill(3) is intended to add a leading zero if needed. However, for seconds <10 (eg. 5.2), "%.1f" % 5.2 evaluates to "5.2". Since this string already consists 3 characters (digit, dot, digit), zfill(3) will not add leading 0. So wee see 12:05:5.2 instead of the intended 12:05:05.2.
Fix: use a width of 4 characters because the format includes: two digits, a dot, and one decimal place.