### PR TITLE
Issue 366

### DIFF
--- a/bdsf/gausfit.py
+++ b/bdsf/gausfit.py
@@ -23,6 +23,7 @@ if has_pl:
 import scipy.ndimage as nd
 from . import multi_proc as mp
 import itertools
+import sys
 
 
 class Op_gausfit(Op):
@@ -463,6 +464,14 @@ class Op_gausfit(Op):
                                                       isl.image, size)
             except ValueError:
                 pass
+
+            except IndexError:
+                print("IndexError in fit_island():", file=sys.stderr)
+                try:
+                    print(f"  {fit_image.shape=}", file=sys.stderr)
+                    print(f"  {mompara=}, {x1=}, {y1=}, {t=}, {u=}", file=sys.stderr)
+                except (AttributeError, NameError):
+                    pass
 
         # Return whatever we got
         if verbose:

--- a/bdsf/multi_proc.py
+++ b/bdsf/multi_proc.py
@@ -68,12 +68,11 @@ def worker(f, ii, chunk, out_q, err_q, lock, bar, bar_state, preserve_order=Fals
         try:
             result = f(val)
         except Exception as e:
-            etype, val, tbk = sys.exc_info()
-            print('Thread raised exception', e)
-            print('Traceback of thread is:')
-            print('-------------------------')
-            traceback.print_tb(tbk)
-            print('-------------------------')
+            print("Thread raised exception", e, file=sys.stderr)
+            print("Traceback of thread is:", file=sys.stderr)
+            print("-------------------------", file=sys.stderr)
+            traceback.print_exception(e, file=sys.stderr)
+            print("-------------------------", file=sys.stderr)
             err_q.put(e)
             return
 


### PR DESCRIPTION
This should fix the `IndexError` in the `fit_island()` method that is triggered in rare occasions, probably when a Gaussian source is found very close to the edge of the image, thus causing the interpolation to index a pixel that is just outside the image boundaries.

At the same time, this fixes a bug where part of the exception message that is printed in the `worker()` method of `multi_proc.py` was sent to `stdout` and part to `stderr`. Now all lines are sent to `stderr`.