### PR TITLE
Fix pixel count mismatch between total flux and its error

### DIFF
--- a/bdsf/islands.py
+++ b/bdsf/islands.py
@@ -371,7 +371,7 @@ class Island(object):
         # Calculate background-subtracted total flux
         self.total_flux = N.nansum((self.image - bbox_mean_im)[valid_pixels]) / beamarea
 
-        pixels_in_isl = N.sum(~N.isnan(self.image[~self.mask_active]))  # number of unmasked pixels assigned to current island
+        pixels_in_isl = N.sum(valid_pixels)
         self.total_fluxE = func.nanmean(bbox_rms_im[valid_pixels]) * N.sqrt(pixels_in_isl/beamarea)  # Jy
         self.border = self.get_border()
         self.gaul = []


### PR DESCRIPTION
`total_flux` relied on `valid_pixels`, but the flux uncertainty (`total_fluxE`) calculated its pixel count (`pixels_in_isl`) by checking for NaNs in the image only. If the background map contained NaNs, `pixels_in_isl` overestimated the actual number of pixels used for the flux.