### PR TITLE
Fix degree-to-pixel fallback in `angdist2pixdist`

### DIFF
--- a/bdsf/readimage.py
+++ b/bdsf/readimage.py
@@ -575,9 +575,9 @@ class Op_readimage(Op):
         if angdist12 > 0.0:
             result = angdist * pixdist12 / angdist12
             if N.isnan(result) or result <= 0.0:
-                result = N.mean(img.wcs_obj.acdelt[0:2])
+                result = angdist / N.mean(img.wcs_obj.acdelt[0:2])  # Convert degrees to pixels: [deg] / [deg/pix]
         else:
-            result = N.mean(img.wcs_obj.acdelt[0:2])
+            result = angdist / N.mean(img.wcs_obj.acdelt[0:2])      # Convert degrees to pixels: [deg] / [deg/pix]
         return result
 
 


### PR DESCRIPTION
When geometry calculations fail or produce invalid results, the fallback now correctly divides `angdist` by the pixel scale (`angdist / acdelt`) to return the distance in pixels instead of returning pixel scale in degrees.