### PR TITLE
Fix plotting in `psfvary.py`

### DIFF
--- a/bdsf/psf_vary.py
+++ b/bdsf/psf_vary.py
@@ -863,7 +863,7 @@ class Op_psf_vary(Op):
 
         if plot:
             pl.figure(None)
-            colours=['b','g','r','c','m','y','k']*(len(xt)/7+1)
+            colours = [ 'b','g','r','c','m','y','k' ] * (len(xt) // 7+1 )
             pl.axis([0.0, image.shape[0], 0.0, image.shape[1]])
             pl.title('Tesselated image with tile centres and unresolved sources')
             for i in range(ntile):


### PR DESCRIPTION
This is a leftover from Python 2. Dividing using `/` in Python 3 produces a float and it is forbidden to multiply a list by a float (`TypeError`). Use floor division instead.