### PR TITLE
Fix handling invalid slice in RMS MAD calculation

### DIFF
--- a/bdsf/rmsimage.py
+++ b/bdsf/rmsimage.py
@@ -979,7 +979,9 @@ class Op_rmsimage(Op):
                     
                     # Protection against zero noise (e.g. all pixels have the same value)
                     if cr == 0.0:
-                        cr = np.std(valid_pixels) # final fallback
+                        cr = np.std(valid_pixels) # fallback
+                        if cr == 0.0:
+                            cr = np.inf           # finall fallback
                 else: # too few unmasked pixels --> set mean/rms to inf
                     cm = np.inf
                     cr = np.inf


### PR DESCRIPTION
If all the pixel values are equal, this still will be 0. So add another fallback. This Inf will be processed further in `rms_mean_map`.