### PR TITLE
Fix flux and RMS calculation in plotting

### DIFF
--- a/bdsf/plotresults.py
+++ b/bdsf/plotresults.py
@@ -556,21 +556,18 @@ def on_press(event):
                 break
         if not has_image:
             return
-        if xmin < 0:
-            xmin = 0
-        if xmax > img_ch0.shape[0]:
-            xmax = img_ch0.shape[0]
-        if ymin < 0:
-            ymin = 0
-        if ymax > img_ch0.shape[1]:
-            ymax = img_ch0.shape[1]
 
-        # Ensure slice indices are int, then get various values for the
-        # visible region
-        xmin = int(xmin)
-        xmax = int(xmax)
-        ymin = int(ymin)
-        ymax = int(ymax)
+        # Sort the boundaries
+        x_start = int(min(xmin, xmax))
+        x_end = int(max(xmin, xmax))
+        y_start = int(min(ymin, ymax))
+        y_end = int(max(ymin, ymax))
+
+        xmin = max(0, x_start)
+        xmax = min(img_ch0.shape[0], x_end)
+        ymin = max(0, y_start)
+        ymax = min(img_ch0.shape[1], y_end)
+
         flux = N.nansum(img_ch0[xmin:xmax, ymin:ymax])/pixels_per_beam
         mask = N.isnan(img_ch0[xmin:xmax, ymin:ymax])
         num_pix_unmasked = float(N.size(N.where(mask == False), 1))


### PR DESCRIPTION
**Bug**
The code fetched boundaries via `ax.get_xlim()` and `ax.get_ylim()`. In the case of images with reversed axes (such as RA orientation in astronomy, which increases to the left), zooming in caused these functions to return the boundaries in reverse order (xmin > xmax). Slicing a NumPy array this way (e.g., img_ch0[100:20]) doesn't throw an error, but it returns an empty array. In result, the flux and RMS for the zoomed region were 0.0.

**Fix**
The limits are now sorted first.