### PR TITLE
Fix shapelets statistics

### DIFF
--- a/bdsf/make_residimage.py
+++ b/bdsf/make_residimage.py
@@ -157,11 +157,11 @@ class Op_make_residimage(Op):
 
             if img.opts.residual_stats_do:
                 # Calculate some statistics for the Shapelet residual image
-                non_masked = N.where(~N.isnan(img.ch0_arr))
-                mean = N.mean(resid_shap[non_masked], axis=None)
-                std_dev = N.std(resid_shap[non_masked], axis=None)
-                skew = stats.skew(resid_shap[non_masked], axis=None)
-                kurt = stats.kurtosis(resid_shap[non_masked], axis=None)
+                resid_shap_non_masked = resid_shap[~N.isnan(resid_shap)]
+                mean = N.mean(resid_shap_non_masked, axis=None)
+                std_dev = N.std(resid_shap_non_masked, axis=None)
+                skew = stats.skew(resid_shap_non_masked, axis=None)
+                kurt = stats.kurtosis(resid_shap_non_masked, axis=None)
                 mylog.info("Statistics of the Shapelet residual image:")
                 mylog.info("        mean: %.3e (Jy/beam)" % mean)
                 mylog.info("    std. dev: %.3e (Jy/beam)" % std_dev)


### PR DESCRIPTION
**Problem**
Shapelet residual statistics returned NaN because valid pixel indices were selected using the original image (img.ch0_arr) rather than resid_shap. This allowed newly masked NaN values in resid_shap to pass into the statistical numpy functions.

**Fix**
Replaced img.ch0_arr indexing with direct NaN filtering on the shapelet residual array itself using `resid_shap[~N.isnan(resid_shap)]`.