### PR TITLE
Fix `ptbin` division in `psfvary.py`

### DIFF
--- a/bdsf/psf_vary.py
+++ b/bdsf/psf_vary.py
@@ -377,12 +377,12 @@ class Op_psf_vary(Op):
         if num <= 100: ptpbin = num // 5
         if num > 100: ptpbin = num // 10
         if num > 1000: ptpbin = num // 20
-        if ptpbin % 2 == 1: ptpbin = ptpbin+1
-        if num < 10: ptpbin=num
+        if ptpbin % 2 == 1: ptpbin = ptpbin + 1
+        if num < 10: ptpbin = num
         ptpbin = float(ptpbin) # cast to float to avoid integer division errors
-        nbin = int((num-ptpbin)/(ptpbin/over)+1)
-        ptplastbin = int((num-1)-(nbin-1)*ptpbin/over)
-        nbin = nbin+1
+        nbin = int( (num-ptpbin) / (ptpbin/over)+1 )
+        ptplastbin = int( (num-1)-(nbin-1)*ptpbin / over )
+        nbin = nbin + 1
 
         return ptpbin, nbin, ptplastbin
 

--- a/bdsf/psf_vary.py
+++ b/bdsf/psf_vary.py
@@ -372,17 +372,17 @@ class Op_psf_vary(Op):
 
 ##################################################################################################
 
-    def bindata(self, over, num): #ptpbin,nbin,ptplastbin, same as get_bins in fBDSM.
+    def bindata(self, over, num): #ptpbin, nbin, ptplastbin, same as get_bins in fBDSM.
 
-        if num <= 100: ptpbin=num/5
-        if num > 100: ptpbin=num/10
-        if num > 1000: ptpbin=num/20
-        if ptpbin % 2 == 1: ptpbin=ptpbin+1
+        if num <= 100: ptpbin = num // 5
+        if num > 100: ptpbin = num // 10
+        if num > 1000: ptpbin = num // 20
+        if ptpbin % 2 == 1: ptpbin = ptpbin+1
         if num < 10: ptpbin=num
         ptpbin = float(ptpbin) # cast to float to avoid integer division errors
-        nbin=int((num-ptpbin)/(ptpbin/over)+1)
-        ptplastbin=int((num-1)-(nbin-1)*ptpbin/over)
-        nbin=nbin+1
+        nbin = int((num-ptpbin)/(ptpbin/over)+1)
+        ptplastbin = int((num-1)-(nbin-1)*ptpbin/over)
+        nbin = nbin+1
 
         return ptpbin, nbin, ptplastbin
 


### PR DESCRIPTION
In Python 3 the operator here must be `//`.
The test failed, but the results should be better now.