### PR TITLE
Fix PA angle normalization in `deconv2`

### DIFF
--- a/bdsf/functions.py
+++ b/bdsf/functions.py
@@ -678,8 +678,8 @@ def deconv2(gaus_bm, gaus_c):
 
     rad = 180.0/pi
 
-    phi_c = gaus_c[2]+900.0 % 180.0
-    phi_bm = gaus_bm[2]+900.0 % 180.0
+    phi_c = gaus_c[2] % 180.0
+    phi_bm = gaus_bm[2] % 180.0
     theta1 = phi_c / rad
     theta2 = phi_bm / rad
     bmaj1 = gaus_c[0]


### PR DESCRIPTION
This appears to be a precedence bug. The intended expression is:

`(gaus_c[2] + 900.0) % 180.0`

The 900 (5*180) is a legacy from Fortran, where MOD() could return negative values. In Python, % already normalizes negative angles into [0, 180), so `% 180.0` is sufficient.