### PR TITLE
Fix masked pixels included in image moment calculations

### DIFF
--- a/bdsf/functions.py
+++ b/bdsf/functions.py
@@ -379,8 +379,8 @@ def moment(x,mask=None):
     for i, val in N.ndenumerate(x):
         if not mask[i]:
             m1 += val
-        m2 += val*N.array(i)
-        m3 += val*N.array(i)*N.array(i)
+            m2 += val*N.array(i)
+            m3 += val*N.array(i)*N.array(i)
     m2 /= m1
     if N.all(m3/m1 > m2*m2):
         m3 = N.sqrt(m3/m1-m2*m2)


### PR DESCRIPTION
Due to incorrect indentation, m2 (centroid) and m3 (variance) are accumulated outside the `if not mask[i]` block. So masked pixels are included in the numerators while being excluded from the denominator (m1). This leads to biased estimates of the centroid and size.