### PR TITLE
Fix incorrect coordinate shift in `process_Multiple`

### DIFF
--- a/bdsf/gaul2srl.py
+++ b/bdsf/gaul2srl.py
@@ -353,7 +353,7 @@ class Op_gaul2srl(Op):
                 maxpeak = para[0]
             else:
                 maxpeak = maxv
-            posn = para[1:3]-(0.5*N.sum(s_imsize)-1)/2.0+N.array([maxx, maxy])-1+delc
+            posn = para[1:3] + blc + delc
         else:
             maxpeak = maxv
             posn = N.unravel_index(N.argmax(data*~rmask), data.shape)+N.array(delc) +blc


### PR DESCRIPTION
After successfully fitting a 2D Gaussian to the sub-image, the code attempts to map the local fitted coordinates (`para[1:3]`) back to the global image.

**Bug**
`s_imsize` contains the X and Y sizes of the bounding box. `N.sum(s_imsize)` sums these two dimensions. Taking half of this sum and applying it as a uniform offset to *both* X and Y incorrectly assumes the sub-image is always square.

**Fix**
The correct offset from a sub-image to the parent image is simply the bottom left corner index (`blc`).