### PR TITLE
Fix flux error aggregation for multi-component sources

### DIFF
--- a/bdsf/gaul2srl.py
+++ b/bdsf/gaul2srl.py
@@ -444,11 +444,10 @@ class Op_gaul2srl(Op):
 
         # update all objects etc
         tot = 0.0
-        totE_sq = 0.0
+        totE = 0.0
         for g in g_sublist:
             tot += g.total_flux
-            totE_sq += g.total_fluxE**2
-        totE = sqrt(totE_sq)
+            totE += g.total_fluxE
         size_pix = [mompara[3], mompara[4], mompara[5]]
         size_sky = img.pix2gaus(size_pix, [mompara[1]+delc[0], mompara[2]+delc[1]])
         size_sky_uncorr = img.pix2gaus(size_pix, [mompara[1]+delc[0], mompara[2]+delc[1]], use_wcs=False)

--- a/doc/source/algorithms.rst
+++ b/doc/source/algorithms.rst
@@ -60,7 +60,7 @@ Inside each island, groups of Gaussians are deemed to be a part of the same sour
     1. the difference between the minimum value along the line joining the centers of any pair of Gaussians and the peak value of the lower Gaussian is less than the product of the island threshold and the island rms, and
     2. the centers are separated by a distance less than half the sum of their FWHMs along the line joining them.
 
-Once the Gaussians that belong to a source are identified, fluxes for the grouped Gaussians are summed to obtain the total flux of the source. The uncertainty on the total flux is calculated by summing the uncertainties on the total fluxes of the individual Gaussians in quadrature. The source RA and Dec position is set to the source centroid determined from moment analysis (the position of the maximum of the source is also calculated). The total source size is also measured using moment analysis (see https://en.wikipedia.org/wiki/Image_moment for an overview of moment analysis).
+Once the Gaussians that belong to a source are identified, fluxes for the grouped Gaussians are summed to obtain the total flux of the source. The uncertainty on the total flux is calculated by linearly summing the uncertainties on the total fluxes of the individual Gaussians to account for component covariance. The source RA and Dec position is set to the source centroid determined from moment analysis (the position of the maximum of the source is also calculated). The total source size is also measured using moment analysis (see https://en.wikipedia.org/wiki/Image_moment for an overview of moment analysis).
 
 .. _colorcorrections:
 


### PR DESCRIPTION
`totE` (total flux error) in multi-Gaussian sources was underestimated. Aggregating errors in quadrature assumes independent Gaussian components, which is invalid for overlapping fits within a single island.

**Fix**
Replaced root-sum-square addition with linear summation to account for component covariance (in the absence of a full covariance matrix).