### PR TITLE
Fix stability of MC error estimation in `gaul2srl.py`

### DIFF
--- a/bdsf/gaul2srl.py
+++ b/bdsf/gaul2srl.py
@@ -463,7 +463,7 @@ class Op_gaul2srl(Op):
         errors = func.get_errors(img, plist, isl.rms)
 
         if img.opts.do_mc_errors:
-            nMC = 20
+            nMC = 200
             mompara0_MC = N.zeros(nMC, dtype=N.float32)
             mompara1_MC = N.zeros(nMC, dtype=N.float32)
             mompara2_MC = N.zeros(nMC, dtype=N.float32)


### PR DESCRIPTION
20 iterations in MC is a very low number. It was defined at least 15y ago according to BLAME.  It would be better to use 1k (2% variance), but for a compromise, maybe 200 is enough.

The variance of the estimator drops from ~16.2% to ~5.0%.