### PR TITLE
Fix underestimation of `deconv_size_skyE`

### DIFF
--- a/bdsf/gaul2srl.py
+++ b/bdsf/gaul2srl.py
@@ -519,7 +519,28 @@ class Op_gaul2srl(Op):
                      sqrt(mompara5E**2 + errors[5]**2)]
         sraE, sdecE = (sqrt(mompara1E**2 + errors[1]**2) * sqrt(cdeltsq),
                        sqrt(mompara2E**2 + errors[2]**2) * sqrt(cdeltsq))
-        deconv_size_skyE = size_skyE # set deconvolved errors to non-deconvolved ones
+
+        # Calculate errors for the deconvolved axes using the standard law of error propagation.
+        # Assuming theta_dec = sqrt(theta_obs^2 - theta_beam^2) and a negligible error in beam size,
+        # propagating the uncertainty yields: delta_theta_dec = delta_theta_obs * (theta_obs / theta_dec).
+        deconv_size_skyE = [0.0, 0.0, 0.0]
+
+        # Major axis error
+        if deconv_size_sky[0] > 0.0:
+            deconv_size_skyE[0] = size_skyE[0] * (size_sky[0] / deconv_size_sky[0])
+        else:
+            # Fallback for a point-like source
+            deconv_size_skyE[0] = size_skyE[0]  
+
+        # Minor axis error
+        if deconv_size_sky[1] > 0.0:
+            deconv_size_skyE[1] = size_skyE[1] * (size_sky[1] / deconv_size_sky[1])
+        else:
+            # Fallback for a point-like source
+            deconv_size_skyE[1] = size_skyE[1]
+
+        # Position Angle error is unchanged as a reasonable approximation
+        deconv_size_skyE[2] = size_skyE[2]
 
         # Find aperture flux
         if img.opts.aperture_posn == 'centroid':


### PR DESCRIPTION
This error was simply copied from `size_skyE`, but deconvolution always introduces new uncertainty.