### PR TITLE
Fix weighted sum of squares for the position angle in `psfvary.py`

### DIFF
--- a/bdsf/psf_vary.py
+++ b/bdsf/psf_vary.py
@@ -560,7 +560,7 @@ class Op_psf_vary(Op):
         wtstdbm = N.sqrt((dumrar - wtavbm*wtavbm*sumwt)*sumwt/dd)
 
         avpa  = N.sum(bpa*flagwt-180.0*flagwt*N.array(bpa >= 90))/sumwt
-        stdpa = N.sum(bpa*flagwt+(180.0*180.0-360.0*bpa)*flagwt*N.array(bpa >= 90))
+        stdpa = N.sum(bpa*bpa*flagwt+(180.0*180.0-360.0*bpa)*flagwt*N.array(bpa >= 90))
         stdpa = sqrt(abs((stdpa-avpa*avpa*sumwt)*sumwt/dd))
         if stdpa < wtstdbm[2]:
             wtstdbm[2] = stdpa


### PR DESCRIPTION
**Bug**
When calculating the weighted sum of squares for the position angle (`stdpa`), the `bpa` term was left linear instead of being squared. Because position angles wrap every 180 deg., the code applies a squared correction polynomial for angles $\ge 90^\circ$. Mixing a linear term with squared correction terms results in an invalid variance calculation.

$\sum \left( xw + (180^2 - 360x)w\delta \right)$

**Fix**
Added the missing square to correctly calculate the weighted sum of squares.

$\sum \left( x^2w + (180^2 - 360x)w\delta \right)$