### PR TITLE
Fix position angle normalization in `corrected_size`

### DIFF
--- a/bdsf/functions.py
+++ b/bdsf/functions.py
@@ -243,6 +243,8 @@ def corrected_size(size):
     csize[0] = size[0]*fwsig
     csize[1] = size[1]*fwsig
     bpa = size[2]
+    # Convert to astronomical P.A. and wrap to [0, 180) degrees
+    # Ellipses are rotationally symmetric by 180°, making orientation > 180° redundant
     pa = (bpa - 90.0) % 180.0
     csize[2] = pa
 

--- a/bdsf/functions.py
+++ b/bdsf/functions.py
@@ -243,10 +243,7 @@ def corrected_size(size):
     csize[0] = size[0]*fwsig
     csize[1] = size[1]*fwsig
     bpa = size[2]
-    pa = bpa-90.0
-    pa = pa % 360
-    if pa < 0.0: pa = pa + 360.0
-    if pa > 180.0: pa = pa - 180.0
+    pa = (bpa - 90.0) % 180.0
     csize[2] = pa
 
     return csize


### PR DESCRIPTION
`if pa < 0.0` after `% 360` is a dead code and failed to wrap 180.0° to 0.0°.

**Fix**
`pa = (bpa - 90.0) % 180.0` handles negative inputs and enforces the $[0, 180)$ interval.