### PR TITLE
Remove unnecessary check in `isl_tosplit`

### DIFF
--- a/bdsf/functions.py
+++ b/bdsf/functions.py
@@ -1804,7 +1804,8 @@ def isl_tosplit(isl, opts):
     index = 0
     n_subisl3, labels3, isl_pixs3 = open_isl(isl.mask_active, 3)
     n_subisl5, labels5, isl_pixs5 = open_isl(isl.mask_active, 5)
-    isl_pixs3, isl_pixs5 = N.array(isl_pixs3), N.array(isl_pixs5)
+    isl_pixs3 = N.array(isl_pixs3) if isl_pixs3 is not None else None
+    isl_pixs5 = N.array(isl_pixs5) if isl_pixs5 is not None else None
 
                                 # take open 3 or 5
     open3, open5 = False, False

--- a/bdsf/functions.py
+++ b/bdsf/functions.py
@@ -1803,12 +1803,9 @@ def isl_tosplit(isl, opts):
     size_extra5 = opts.splitisl_size_extra5
     frac_bigisl3 = opts.splitisl_frac_bigisl3
 
-    connected, count = connect(isl.mask_active)
     index = 0
     n_subisl3, labels3, isl_pixs3 = open_isl(isl.mask_active, 3)
     n_subisl5, labels5, isl_pixs5 = open_isl(isl.mask_active, 5)
-    isl_pixs3 = N.array(isl_pixs3) if isl_pixs3 is not None else None
-    isl_pixs5 = N.array(isl_pixs5) if isl_pixs5 is not None else None
 
                                 # take open 3 or 5
     open3, open5 = False, False
@@ -1824,8 +1821,6 @@ def isl_tosplit(isl, opts):
     else:
         if open3: index = 3; n_subisl = n_subisl3; labels = labels3
         else: index = 0
-    convex_def =  convexhull_deficiency(isl)
-    #print 'CONVEX = ',convex_def
 
     if opts.plot_islands:
         try:


### PR DESCRIPTION
**Bug**
Wrapping `None` in `N.array(None)` creates a NumPy array containing `None`, which defeats subsequent `is not None` checks.

**Fix**
Conditionally convert to a NumPy array only if the input is not `None`.