### PR TITLE
Fix Gaussian size error scaling in `g2param_err`

### DIFF
--- a/bdsf/functions.py
+++ b/bdsf/functions.py
@@ -218,21 +218,28 @@ def g2param(g, adj=False):
 
     return params
 
+
 def g2param_err(g, adj=False):
     """Convert errors on gaussian object g to param list [Eamp, Ecenx, Eceny, Esigx, Esigy, Etheta] """
     from .const import fwsig
-    from math import pi
 
     A = g.peak_fluxE
-    if adj and hasattr(g, 'size_pix_adj'):
-        sigx, sigy, th = g.size_pix_adj
+    if adj and hasattr(g, 'size_pix_adj') and hasattr(g, 'size_pix'):
+        scale_x = g.size_pix_adj[0] / g.size_pix[0] if g.size_pix[0] > 0 else 1.0
+        scale_y = g.size_pix_adj[1] / g.size_pix[1] if g.size_pix[1] > 0 else 1.0
+        sigx = g.size_pixE[0] * scale_x
+        sigy = g.size_pixE[1] * scale_y
+        th = g.size_pixE[2]
     else:
         sigx, sigy, th = g.size_pixE
+
     cenx, ceny = g.centre_pixE
-    sigx = sigx/fwsig; sigy = sigy/fwsig
+    sigx = sigx / fwsig
+    sigy = sigy / fwsig
     params = [A, cenx, ceny, sigx, sigy, th]
 
     return params
+
 
 def corrected_size(size):
     """ convert major and minor axis from sigma to fwhm and angle from horizontal to P.A. """


### PR DESCRIPTION
**Bug**
In `g2param_err` where `g.size_pix_adj` (containing size values in pixels) was incorrectly read instead of uncertainty values when `adj=True`.

**Fix**
Scale the actual size errors (`g.size_pixE`) by the ratio `g.size_pix_adj / g.size_pix` when `adj=True`.