### PR TITLE
Fix threshold index search

### DIFF
--- a/bdsf/threshold.py
+++ b/bdsf/threshold.py
@@ -117,7 +117,7 @@ class Op_threshold(Op):
         scnum = sc.n
         index = 0
         for i,s in enumerate(scflux):
-            if s < smin_L:
+            if s > smin_L:
                 index = i
                 break
         n1 = scnum[index]; n2 = scnum[-1]


### PR DESCRIPTION
Because `sc.s` is sorted in ascending order, the original `s < smin_L` condition broke immediately on the first element, locking `index` permanently to `0`.