### PR TITLE
Fix negative RMS map weights near image boundaries

### DIFF
--- a/bdsf/rmsimage.py
+++ b/bdsf/rmsimage.py
@@ -685,7 +685,7 @@ class Op_rmsimage(Op):
                             dist_to_cen = np.sqrt( (x-src_center[0])**2 +
                                                (y-src_center[1])**2 )
                             if dist_to_cen >= med_dist_to_cen:
-                                weights[x,y] = 1.0 - dist_to_cen/np.sqrt(bbox_xsize**2+bbox_ysize**2)*2.0
+                                weights[x,y] = max(0.0, 1.0 - dist_to_cen/np.sqrt(bbox_xsize**2+bbox_ysize**2)*2.0)
                 rms_map[tuple(bbox)] = rms_map1[tuple(bbox)]*weights + out_rms2[tuple(bbox)]*(1.0-weights)
                 mean_map[tuple(bbox)] = mean_map1[tuple(bbox)]*weights + out_mean2[tuple(bbox)]*(1.0-weights)
         else:


### PR DESCRIPTION
**Bug**
RMS maps around bright sources can evaluate to negative values. This happens when `dist_to_cen` exceeds half of the bounding box diagonal - frequently occurs near image boundaries where bounding boxes are cropped.

Negative weights cause `rms_map1 * weights + out_rms2 * (1.0 - weights)` to extrapolate, resulting in negative RMS values.

**Fix**
Clamp the weight to `0.0` to guarantee that `weights` within [0.0, 1.0].