### PR TITLE
Fix corruption of an island mask in `assign_leftovers`

### DIFF
--- a/bdsf/functions.py
+++ b/bdsf/functions.py
@@ -1734,6 +1734,7 @@ def assign_leftovers(mask, open, nisl, labels):
             for cc in coords:
                 # Convert 'cc' to a tuple to properly index the 2D numpy array
                 mask[tuple(cc)] = True
+            return labels, mask
             
         if len(belongs) == 1:
             for cc in coords:

--- a/bdsf/functions.py
+++ b/bdsf/functions.py
@@ -1728,12 +1728,13 @@ def assign_leftovers(mask, open, nisl, labels):
         c_list = list(set(c_list))     # to avoid duplicates
         vals = N.array([labels[c] for c in c_list])
         belongs = list(set(vals[N.nonzero(vals)]))
+
         if len(belongs) == 0:
-            # No suitable islands found => mask pixels
+            # No suitable islands found, so mask individual pixels
             for cc in coords:
-                mask = (mlabels == ii)
-#             mask[cc] = True
-                return None, mask
+                # Convert 'cc' to a tuple to properly index the 2D numpy array
+                mask[tuple(cc)] = True
+            
         if len(belongs) == 1:
             for cc in coords:
                 labels[tuple(cc)] = belongs[0]


### PR DESCRIPTION
**Mask updating**
Replaced the incorrect reassignment (`mask = (mlabels == ii)`) with proper in-place pixel masking (`mask[tuple(cc)] = True`). (There was a commented-out attempt `# mask[cc] = True` indicating the original intent).

**Loop termination**
The return was executed too early, meaning that not all pixels could be processed.