### PR TITLE
Fix invalid IDs assigned to flagged Gaussians in `fgaul`

### DIFF
--- a/bdsf/gausfit.py
+++ b/bdsf/gausfit.py
@@ -156,10 +156,6 @@ class Op_gausfit(Op):
             gaul = gaus_list[idx][0]
             fgaul = gaus_list[idx][1]
             dgaul = []
-            if len(gaul) > 0:
-                gidx = gaul[-1][0]  # save last index value for use with fgaul below
-            else:
-                gidx = 0
             gaul = [Gaussian(img, par, idx, gidx)
                     for (gidx, par) in enumerate(gaul)]
 
@@ -182,7 +178,8 @@ class Op_gausfit(Op):
                 dgaul = [Gaussian(img, par, idx, -1)]
 
             # Now make the list of flagged Gaussians, if any
-            fgaul = [Gaussian(img, par, idx, gidx + gidx2 + 1, flag)
+            start_fgidx = len(gaul)
+            fgaul = [Gaussian(img, par, idx, start_fgidx + gidx2, flag)
                      for (gidx2, (flag, par)) in enumerate(fgaul)]
 
             isl.gaul = gaul


### PR DESCRIPTION
`gaul[-1][0]` was used to find the last Gaussian index, but it actually retrieved the peak flux. Due to Python 3 comprehension scoping, `gidx` retained this value, causing flagged Gaussians to receive invalid IDs.

**Fix**
Used `len(gaul)` as the starting index for `fgaul` items