### PR TITLE
Fix NaN values handling in island peak detection

### DIFF
--- a/bdsf/rmsimage.py
+++ b/bdsf/rmsimage.py
@@ -245,7 +245,7 @@ class Op_rmsimage(Op):
         isl_size_highthresh = []
         for idx, s in enumerate(slices):
             isl_area_lowthresh = (labels[s] == idx+1).sum()/img.pixel_beamarea()*2.0
-            isl_maxposn_lowthresh = tuple(np.array(np.unravel_index(np.argmax(image[s]), image[s].shape))+
+            isl_maxposn_lowthresh = tuple(np.array(np.unravel_index(np.nanargmax(image[s]), image[s].shape))+
                                           np.array((s[0].start, s[1].start)))
             isl_size += [s[0].stop-s[0].start, s[1].stop-s[1].start]
             if do_adapt and isl_maxposn_lowthresh in isl_maxposn:


### PR DESCRIPTION
Prevent incorrect coordinate assignments when image slices contain NaNs and keeps the logic consistent with the high-threshold search block.