### PR TITLE
Fix masked region filling bias towards 0 and loop safety in `fill_masked_regions`

### DIFF
--- a/bdsf/rmsimage.py
+++ b/bdsf/rmsimage.py
@@ -934,14 +934,14 @@ class Op_rmsimage(Op):
         return cm, cr
 
 
-    def fill_masked_regions(self, themap, magic=np.inf):
+    def fill_masked_regions(self, themap):
         """Fill masked regions in themap using local median, with global median fallback."""
         # Compute global median as a fallback for finite values
-        valid_mask = np.isfinite(themap) & (themap != magic)
+        valid_mask = np.isfinite(themap)
         global_fallback = np.nanmedian(themap[valid_mask]) if np.any(valid_mask) else 1.0
 
         # Find coordinates of missing or invalid data
-        masked_boxes = np.where((themap == magic) | np.isnan(themap) | np.isinf(themap))
+        masked_boxes = np.where(~np.isfinite(themap))
         max_delx, max_dely = themap.shape[0], themap.shape[1]
 
         for i in range(np.size(masked_boxes, 1)):
@@ -958,7 +958,7 @@ class Op_rmsimage(Op):
 
                 cutout = themap[x1:x2, y1:y2].ravel()
                 # Extract valid finite values
-                goodcutout = cutout[(cutout != magic) & np.isfinite(cutout)]
+                goodcutout = cutout[np.isfinite(cutout)]
                 num_unmasked = len(goodcutout)
 
                 if num_unmasked > 0:

--- a/bdsf/rmsimage.py
+++ b/bdsf/rmsimage.py
@@ -935,32 +935,42 @@ class Op_rmsimage(Op):
 
 
     def fill_masked_regions(self, themap, magic=np.inf):
-        """Fill masked regions (defined where values == magic) in themap.
-        """
-        masked_boxes = np.where(themap == magic) # locations of masked regions
-        for i in range(np.size(masked_boxes,1)):
+        """Fill masked regions in themap using local median, with global median fallback."""
+        # Compute global median as a fallback for finite values
+        valid_mask = np.isfinite(themap) & (themap != magic)
+        global_fallback = np.nanmedian(themap[valid_mask]) if np.any(valid_mask) else 1.0
+
+        # Find coordinates of missing or invalid data
+        masked_boxes = np.where((themap == magic) | np.isnan(themap) | np.isinf(themap))
+        max_delx, max_dely = themap.shape[0], themap.shape[1]
+
+        for i in range(np.size(masked_boxes, 1)):
             num_unmasked = 0
             x, y = masked_boxes[0][i], masked_boxes[1][i]
             delx = dely = 1
-            while num_unmasked == 0:
-                x1 = x - delx
-                if x1 < 0: x1 = 0
-                x2 = x + 1 + delx
-                if x2 > themap.shape[0]: x2 = themap.shape[0]
-                y1 = y - dely
-                if y1 < 0: y1 = 0
-                y2 = y + 1 + dely
-                if y2 > themap.shape[1]: y2 = themap.shape[1]
+
+            # Search local neighborhood by expanding radius, bounded by image dimensions
+            while num_unmasked == 0 and (delx <= max_delx or dely <= max_dely):
+                x1 = max(0, x - delx)
+                x2 = min(themap.shape[0], x + 1 + delx)
+                y1 = max(0, y - dely)
+                y2 = min(themap.shape[1], y + 1 + dely)
 
                 cutout = themap[x1:x2, y1:y2].ravel()
-                goodcutout = cutout[cutout != magic]
+                # Extract valid finite values
+                goodcutout = cutout[(cutout != magic) & np.isfinite(cutout)]
                 num_unmasked = len(goodcutout)
+
                 if num_unmasked > 0:
-                    themap[x, y] = np.nanmean(goodcutout)
+                    # Use local median from the unmasked neighborhood
+                    themap[x, y] = np.nanmedian(goodcutout)
+
                 delx += 1
                 dely += 1
-        themap[np.isnan(themap)] = 0.0
-        return themap
+
+        # Replace any remaining non-finite values with global RMS median
+        return np.nan_to_num(themap, nan=global_fallback, posinf=global_fallback, neginf=global_fallback)
+
 
     def pad_array(self, arr, new_shape):
         """Returns a padded array by mirroring around the edges."""


### PR DESCRIPTION
- replaced zero-filling with np.nan_to_num using the global RMS median as a fallback.
- switched from np.nanmean to np.nanmedian for local region filling, making estimates robust against outliers.
- bounded the expansion search loop to image boundaries to prevent infinite execution on fully masked inputs.