### PR TITLE
Fix negative `brightsize` values in `rmsimage.py`

### DIFF
--- a/bdsf/rmsimage.py
+++ b/bdsf/rmsimage.py
@@ -187,14 +187,14 @@ class Op_rmsimage(Op):
         # The formula finds the diameter 2r where the brightness drops to 3x the noise level
         # (kappa1 * crms). Solving for 2r gives: 2 * sigma * sqrt(2 * ln(I_max / (3 * sigma_noise)))
         try:
-            brightsize = int(round(2.*img.beam[0]/cdelt[0]/fwsig*
-                               sqrt(2.*log(img.max_value/(kappa1*crms)))))
+            brightsize = round(2.*img.beam[0]/abs(cdelt[0])/fwsig*
+                               sqrt(2.*log(img.max_value/(kappa1*crms))))
         # Fallback: 2-sigma beam
         # If the image contains no sources, `img.max_value` might be 
         # smaller than the noise threshold (kappa1 * crms). This would make the fraction < 1, 
         # causing `log()` to return a negative number, and `sqrt()` to raise a math domain error.
         except (ValueError, ZeroDivisionError):
-            brightsize = int(round(2.*img.beam[0]/cdelt[0]/fwsig))
+            brightsize = round(2.*img.beam[0]/abs(cdelt[0])/fwsig)
 
         mylog.info('Estimated size of brightest source (pixels) = '+str(brightsize))
 


### PR DESCRIPTION
FITS standardly use a negative pixel scale for RA. This caused downstream logic to silently discard the source size estimate and fall back to minimal default box sizes.

Also removed unnecessary cast to int.