### PR TITLE
Fix `fill_masked_regions` triggering

### DIFF
--- a/bdsf/rmsimage.py
+++ b/bdsf/rmsimage.py
@@ -918,8 +918,7 @@ class Op_rmsimage(Op):
                     axes[i][-2] = imgshape[i] - .5
             axes[i][-1] = imgshape[i] - 1
 
-        # Step 5: fill in boxes with < 5 unmasked pixels (set to values of
-        # np.inf)
+        # Step 5: fill in boxes with < 5 unmasked pixels (set to finite values)
         if np.count_nonzero(np.isfinite(mean_map)) < mapshape[0]*mapshape[1]:
             mean_map = self.fill_masked_regions(mean_map)
             rms_map = self.fill_masked_regions(rms_map)

--- a/bdsf/rmsimage.py
+++ b/bdsf/rmsimage.py
@@ -920,7 +920,7 @@ class Op_rmsimage(Op):
 
         # Step 5: fill in boxes with < 5 unmasked pixels (set to values of
         # np.inf)
-        if np.count_nonzero(mean_map != np.inf) < mapshape[0]*mapshape[1]:
+        if np.count_nonzero(np.isfinite(mean_map)) < mapshape[0]*mapshape[1]:
             mean_map = self.fill_masked_regions(mean_map)
             rms_map = self.fill_masked_regions(rms_map)
 


### PR DESCRIPTION
Ensure `fill_masked_regions` is correctly triggered when NaNs exist in the map (`NaN != np.inf` returns `True`).