### PR TITLE
Fix flux underestimation in moment analysis

### DIFF
--- a/bdsf/gausfit.py
+++ b/bdsf/gausfit.py
@@ -449,12 +449,21 @@ class Op_gausfit(Op):
                 mompara = func.momanalmask_gaus(fit_image, mask_id, isl.island_id, pixel_beamarea, True)
                 mompara[5] += 90.0
                 if not N.isnan(mompara[1]) and not N.isnan(mompara[2]):
-                    x1 = int(N.floor(mompara[1]))
-                    y1 = int(N.floor(mompara[2]))
-                    t = (mompara[1]-x1)/(x1+1-x1)
-                    u = (mompara[2]-y1)/(y1+1-y1)
-                    s_peak = ((1.0-t) * (1.0-u) * fit_image[x1, y1] + t * (1.0-u) * fit_image[x1+1, y1] +
-                              t * u * fit_image[x1+1, y1+1] + (1.0-t) * u * fit_image[x1, y1+1])
+                    # Total flux measured from the 0th moment
+                    total_flux_mom = mompara[0]
+                    
+                    # Derive standard deviations (sigma) from returned FWHM
+                    sig_x = (mompara[3] / fwsig) if mompara[3] > 0 else 1.0
+                    sig_y = (mompara[4] / fwsig) if mompara[4] > 0 else 1.0
+                    
+                    # Derive amplitude A = F / (2 * pi * sig_x * sig_y)
+                    # Prevents peak brightness underestimation from bilinear interpolation
+                    gauss_area = 2.0 * N.pi * sig_x * sig_y
+                    if gauss_area > 0.0:
+                        s_peak = total_flux_mom / gauss_area
+                    else:
+                        s_peak = total_flux_mom
+
                     mompara[0] = s_peak
                     par = mompara.tolist()
                     par[3] /= fwsig
@@ -462,7 +471,7 @@ class Op_gausfit(Op):
                     gaul, fgaul = self.flag_gaussians([par], opts,
                                                       beam, thr0, peak, shape, isl.mask_active,
                                                       isl.image, size)
-            except ValueError:
+            except (ValueError, ZeroDivisionError):
                 pass
 
             except IndexError:


### PR DESCRIPTION
Moment analysis estimated peak brightness using bilinear interpolation on pixels around the center. Because a 2D Gaussian profile is concave near its peak, linear interpolation underestimates the peak amplitude $A$ (up to ~40%).

**Fix**
Replaced grid interpolation with an amplitude calculation: $A = F / (2\pi \sigma_x \sigma_y)$, derived from the 0th moment total flux $F$ and $\sigma$.