### PR TITLE
Fix invalid `CDELT4` value in output FITS header

### DIFF
--- a/bdsf/functions.py
+++ b/bdsf/functions.py
@@ -1205,7 +1205,7 @@ def make_fits_image(imagedata, wcsobj, beam, freq, equinox, telescope, xmin=0, y
     # Add frequency info
     header['RESTFRQ'] = freq
     header['CRVAL4'] = freq
-    header['CDELT4'] = 3e8
+    # header['CDELT4'] = 3e8
     header['CRPIX4'] = 1.0
     header['CUNIT4'] = 'HZ'
     header['CTYPE4'] = 'FREQ'


### PR DESCRIPTION
This is obviously not true these days. In this case maybe better to comment it out, co that full list of FITS keyword is still there.