### PR TITLE
Fix RMS explosion near strong sources

### DIFF
--- a/bdsf/rmsimage.py
+++ b/bdsf/rmsimage.py
@@ -1023,14 +1023,20 @@ class Op_rmsimage(Op):
         bstat = func.bstat #_cbdsm.bstat
         a, b, c, d = ind
         if mask is None:
-            m, r, cm, cr, cnt = bstat(arr[a:b, c:d], mask, kappa)
-            if cnt > 198: cm = m; cr = r
+            _, _, cm, cr, cnt = bstat(arr[a:b, c:d], mask, kappa)
+            if cnt > 198: # use MAD
+                sub_arr = arr[a:b, c:d]
+                cm = np.nanmedian(sub_arr)
+                cr = np.nanmedian(np.abs(sub_arr - cm)) * 1.4826
         else:
             pix_unmasked = np.where(mask[a:b, c:d] == False)
             npix_unmasked = np.size(pix_unmasked,1)
             if npix_unmasked > 20: # find clipped mean/rms
-                m, r, cm, cr, cnt = bstat(arr[a:b, c:d], mask[a:b, c:d], kappa)
-                if cnt > 198: cm = m; cr = r
+                _, _, cm, cr, cnt = bstat(arr[a:b, c:d], mask[a:b, c:d], kappa)
+                if cnt > 198: # use MAD
+                    sub_arr = arr[a:b, c:d][pix_unmasked]
+                    cm = np.nanmedian(sub_arr)
+                    cr = np.nanmedian(np.abs(sub_arr - cm)) * 1.4826
             else:
                 if npix_unmasked > 5: # same logic as in 'for_masked'
                     # First take the same windows for which the mask was calculated

--- a/bdsf/rmsimage.py
+++ b/bdsf/rmsimage.py
@@ -14,6 +14,7 @@ from concurrent.futures import ThreadPoolExecutor
 
 import numpy as np
 from scipy import interpolate, ndimage
+from scipy.stats import median_abs_deviation
 
 from .image import Op
 from . import const
@@ -1034,28 +1035,26 @@ class Op_rmsimage(Op):
         a, b, c, d = ind
         if mask is None:
             _, _, cm, cr, cnt = bstat(arr[a:b, c:d], mask, kappa)
-            if cnt > 198: # use MAD
+            if cnt > 198:
                 sub_arr = arr[a:b, c:d]
                 cm = np.nanmedian(sub_arr)
-                cr = np.nanmedian(np.abs(sub_arr - cm)) * 1.4826
+                cr = median_abs_deviation(sub_arr, axis=None, nan_policy='omit', scale='normal')
         else:
             pix_unmasked = np.where(mask[a:b, c:d] == False)
             npix_unmasked = np.size(pix_unmasked,1)
             if npix_unmasked > 20: # find clipped mean/rms
                 _, _, cm, cr, cnt = bstat(arr[a:b, c:d], mask[a:b, c:d], kappa)
-                if cnt > 198: # use MAD
+                if cnt > 198:
                     sub_arr = arr[a:b, c:d][pix_unmasked]
                     cm = np.nanmedian(sub_arr)
-                    cr = np.nanmedian(np.abs(sub_arr - cm)) * 1.4826
+                    cr = median_abs_deviation(sub_arr, axis=None, nan_policy='omit', scale='normal')
             else:
                 if npix_unmasked > 5: # same logic as in 'for_masked'
                     # First take the same windows for which the mask was calculated
                     # and then select only the unmasked pixels
                     valid_pixels = arr[a:b, c:d][pix_unmasked]
                     cm = np.nanmedian(valid_pixels)
-                    # Calculate standard deviation estimated from Median Absolute Deviation (MAD)
-                    # MAD = median(|x - median(x)|). The scale factor for a Gaussian distribution is 1.4826
-                    cr = np.nanmedian(np.abs(valid_pixels - cm)) * 1.4826
+                    cr = median_abs_deviation(valid_pixels, axis=None, nan_policy='omit', scale='normal')
                     
                     # Protection against zero noise (e.g. all pixels have the same value)
                     if cr == 0.0:


### PR DESCRIPTION
When `bstat` fails to converge within `cnt > 198`, the algorithm fell back to the unclipped mean and std (`cm = m; cr = r`). In regions containing bright sources, the unclipped std is inflated by source brightness, resulting in local RMS "explosions".