### PR TITLE
Fix false rejection of rms map

### DIFF
--- a/bdsf/rmsimage.py
+++ b/bdsf/rmsimage.py
@@ -482,10 +482,15 @@ class Op_rmsimage(Op):
         cdelt = img.wcs_obj.acdelt[:2]
         bm = (img.beam[0], img.beam[1])
         fw_pix = sqrt(np.prod(bm)/abs(np.prod(cdelt)))
+        # Subsample RMS map at box step size to evaluate variance on coarse grid
+        # rather than smoothed interpolation
+        step = max(1, int(img.rms_box[1]))
         if img.masked:
-            stdsub = np.std(rms[~img.mask_arr])
+            sub_rms = rms[::step, ::step]
+            sub_mask = img.mask_arr[::step, ::step]
+            stdsub = np.std(sub_rms[~sub_mask])
         else:
-            stdsub = np.std(rms)
+            stdsub = np.std(rms[::step, ::step])
 
         rms_expect = img.clipped_rms/sqrt(2)/img.rms_box[0]*fw_pix
         mylog.debug('%s %10.6f %s' % ('Standard deviation of rms image = ', stdsub*1000.0, 'mJy'))

--- a/bdsf/rmsimage.py
+++ b/bdsf/rmsimage.py
@@ -484,6 +484,8 @@ class Op_rmsimage(Op):
         fw_pix = sqrt(np.prod(bm)/abs(np.prod(cdelt)))
         # Subsample RMS map at box step size to evaluate variance on coarse grid
         # rather than smoothed interpolation
+        # Determines the sampling step size in pixels (RMS box step)
+        # and enfore a minimum value to prevent a zero-step slice
         step = max(1, int(img.rms_box[1]))
         if img.masked:
             sub_rms = rms[::step, ::step]

--- a/bdsf/rmsimage.py
+++ b/bdsf/rmsimage.py
@@ -485,7 +485,7 @@ class Op_rmsimage(Op):
         # Subsample RMS map at box step size to evaluate variance on coarse grid
         # rather than smoothed interpolation
         # Determines the sampling step size in pixels (RMS box step)
-        # and enfore a minimum value to prevent a zero-step slice
+        # and enforce a minimum value to prevent a zero-step slice
         step = max(1, int(img.rms_box[1]))
         if img.masked:
             sub_rms = rms[::step, ::step]


### PR DESCRIPTION
`check_rmsmap` evaluates standard deviation (`stdsub`) on the interpolated pixel array (`rms`). Interpolation acts as a low-pass filter, depressing pixel variance below the expectation (`rms_expect`). Consequently, `stdsub` frequently falls below the `1.1 * rms_expect` threshold, causing varying RMS maps to be rejected and replaced with a constant (`use_rms_map = False`).

**Fix**
Subsampled the `rms` map and `mask_arr` at step increments corresponding to the evaluation grid step size (`img.rms_box[1]`) before computing `stdsub`.