### PR TITLE
Partially revert `Fix jmax calcultion in wavelets`

### DIFF
--- a/bdsf/wavelet_atrous.py
+++ b/bdsf/wavelet_atrous.py
@@ -85,7 +85,7 @@ class Op_wavelet_atrous(Op):
                     min_size = min(max_isl_shape) * 4.0
                 else:
                     min_size = min(resid.shape)
-                jmax = floor(log((min_size / 3.0 * 3.0 - l) / (l - 1) + 1) / log(2.0) + 1.0) + 1
+                jmax = floor(log((min_size - l) / (l - 1) + 1) / log(2.0) + 1.0) + 1
                 if min_size * 0.55 <= (l + (l - 1) * (2 ** (jmax) - 1)):
                     jmax = jmax - 1
             img.wavelet_lpf = lpf

--- a/bdsf/wavelet_atrous.py
+++ b/bdsf/wavelet_atrous.py
@@ -85,7 +85,7 @@ class Op_wavelet_atrous(Op):
                     min_size = min(max_isl_shape) * 4.0
                 else:
                     min_size = min(resid.shape)
-                jmax = floor(log(((min_size // 3) * 3.0 - l) / (l - 1) + 1) / log(2.0) + 1.0) + 1
+                jmax = floor(log((min_size / 3.0 * 3.0 - l) / (l - 1) + 1) / log(2.0) + 1.0) + 1
                 if min_size * 0.55 <= (l + (l - 1) * (2 ** (jmax) - 1)):
                     jmax = jmax - 1
             img.wavelet_lpf = lpf


### PR DESCRIPTION
Using `(min_size // 3) * 3.0` truncates the size (e.g., 100 becomes 99). It can drop the `jmax` scale by 1, degrading the algorithm's ability to extract extended sources.

Since `... / 3.0 * 3.0` is likely an artifact with no mathematical justification, we should probably remove these redundant operations in the future.

For now I reverted this line, keeping the removal of the redundant `int()` cast.

Thanks for @Bartoszsmierciak for noticing the regression.