### PR TITLE
Revert `Fix RMS explosion near strong sources`

### DIFF
--- a/bdsf/rmsimage.py
+++ b/bdsf/rmsimage.py
@@ -1034,27 +1034,23 @@ class Op_rmsimage(Op):
         bstat = func.bstat #_cbdsm.bstat
         a, b, c, d = ind
         if mask is None:
-            _, _, cm, cr, cnt = bstat(arr[a:b, c:d], mask, kappa)
-            if cnt > 198:
-                sub_arr = arr[a:b, c:d]
-                cm = np.nanmedian(sub_arr)
-                cr = median_abs_deviation(sub_arr, axis=None, nan_policy='omit', scale='normal')
+            m, r, cm, cr, cnt = bstat(arr[a:b, c:d], mask, kappa)
+            if cnt > 198: cm = m; cr = r
         else:
             pix_unmasked = np.where(mask[a:b, c:d] == False)
             npix_unmasked = np.size(pix_unmasked,1)
             if npix_unmasked > 20: # find clipped mean/rms
-                _, _, cm, cr, cnt = bstat(arr[a:b, c:d], mask[a:b, c:d], kappa)
-                if cnt > 198:
-                    sub_arr = arr[a:b, c:d][pix_unmasked]
-                    cm = np.nanmedian(sub_arr)
-                    cr = median_abs_deviation(sub_arr, axis=None, nan_policy='omit', scale='normal')
+                m, r, cm, cr, cnt = bstat(arr[a:b, c:d], mask[a:b, c:d], kappa)
+                if cnt > 198: cm = m; cr = r
             else:
                 if npix_unmasked > 5: # same logic as in 'for_masked'
                     # First take the same windows for which the mask was calculated
                     # and then select only the unmasked pixels
                     valid_pixels = arr[a:b, c:d][pix_unmasked]
                     cm = np.nanmedian(valid_pixels)
-                    cr = median_abs_deviation(valid_pixels, axis=None, nan_policy='omit', scale='normal')
+                    # Calculate standard deviation estimated from Median Absolute Deviation (MAD)
+                    # MAD = median(|x - median(x)|). The scale factor for a Gaussian distribution is 1.4826
+                    cr = np.nanmedian(np.abs(valid_pixels - cm)) * 1.4826
                     
                     # Protection against zero noise (e.g. all pixels have the same value)
                     if cr == 0.0:


### PR DESCRIPTION
That PR was a regression. It ignored the clipped statistics from `bstat` and uses the unclipped statistics, which should actually be worse, despite MAD is used now.
The efficiency of bstat should be optimized instead. (I will extract few cases and see how well `bstat` actually works, but thats another issue).

I'm sorry. I will review my PRs to identify any possible regressions. It may take some time...